### PR TITLE
Add phantomjs to dependencies globally installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Building the frontend requires you to have nodejs and gulp install. While the ra
 
 Once node is installed, you can run the following commands to ensure that all dependencies are installed:
 ```bash
-npm install -g bower gulp gulp-util gulp-load-plugins del gulp-git
+npm install -g bower gulp gulp-util gulp-load-plugins del gulp-git phantomjs
 ```
 
 ## Building the frontend


### PR DESCRIPTION
Phantomjs should be installed gloabally to avoid `npm install` to fail.
