### PR TITLE
Fixed bugs in the staff page and added improvments

### DIFF
--- a/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
@@ -1,0 +1,32 @@
+# Service to update the current user
+
+# We're not using angular-devise as the update functionality hasn't been
+# merged yet.
+# As we're using Devise + Her, we have custom routes to update the current user
+# It then makes more sense to have an extra service rather than have customised
+# fork of the upstream library
+
+
+@App.service 'MnoeCurrentUser', (MnoeApiSvc, $window, $state) ->
+  _self = @
+
+  # Store the current_user promise
+  # Only one call will be executed even if there is multiple callers at the same time
+  userPromise = null
+
+  # Save the current user in variable to be able to reference it directly
+  @user = {}
+
+  # Get the current user admmin role
+  @getAdminRole = ->
+    return userPromise if userPromise?
+    userPromise = MnoeApiSvc.one('current_user').get().then(
+      (response) ->
+
+        adminRole = {admin_role: response.data.admin_role}
+
+        angular.copy(adminRole, _self.user)
+        response
+    )
+
+  return @

--- a/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
@@ -22,9 +22,7 @@
     return userPromise if userPromise?
     userPromise = MnoeApiSvc.one('current_user').get().then(
       (response) ->
-
         adminRole = {admin_role: response.data.admin_role}
-
         angular.copy(adminRole, _self.user)
         response
     )

--- a/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
@@ -49,7 +49,7 @@
   # Update the admin-role of a staff to nothing
   # UPDATE /mnoe/jpi/v1/admin/users/:id
   @removeStaff = (id) ->
-    promise = MnoeAdminApiSvc.one('users', id).patch({admin_role: ""}).then(
+    promise = MnoeAdminApiSvc.one('users', id).remove().then(
       (response) ->
         MnoeObservables.notifyObservers(OBS_KEYS.staffChanged, promise)
       (error) ->

--- a/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
@@ -1,5 +1,5 @@
 # Service for managing the users.
-@App.service 'MnoeUsers', ($q, $log, MnoeAdminApiSvc, MnoeObservables, ADMIN_ROLES, OBS_KEYS) ->
+@App.service 'MnoeUsers', ($q, $log, MnoeAdminApiSvc, MnoeObservables, OBS_KEYS) ->
   _self = @
 
   @list = (limit, offset, sort) ->
@@ -10,9 +10,9 @@
     )
 
   @staffs = (limit, offset, sort, params = {}) ->
-    # Require only users with an admin role
+    # Require only users with an admin role (gets any role, not necessarly defined in the frontend)
     if ! params['where[admin_role.in][]']
-      params['where[admin_role.in][]'] = ADMIN_ROLES
+      params['where[admin_role.not]'] = ''
 
     return _getStaffs(limit, offset, sort, params)
 

--- a/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/users.svc.coffee
@@ -49,7 +49,7 @@
   # Update the admin-role of a staff to nothing
   # UPDATE /mnoe/jpi/v1/admin/users/:id
   @removeStaff = (id) ->
-    promise = MnoeAdminApiSvc.one('users', id).remove().then(
+    promise = MnoeAdminApiSvc.one('users', id).patch({admin_role: ""}).then(
       (response) ->
         MnoeObservables.notifyObservers(OBS_KEYS.staffChanged, promise)
       (error) ->

--- a/frontend-admin/src/app/components/mnoe-staffs-list/mnoe-staffs-list.coffee
+++ b/frontend-admin/src/app/components/mnoe-staffs-list/mnoe-staffs-list.coffee
@@ -86,7 +86,7 @@
           console.log 'Remove staff role:' + staff
           MnoeUsers.removeStaff(staff.id).then( ->
             toastr.success("#{staff.name} #{staff.surname} has been successfully removed.")
-            )
+          )
         )
 
     # Fetch staffs
@@ -102,11 +102,11 @@
     fetchStaffs(vm.staff.nbItems, 0).then( ->
       # Notify me if a user is added
       MnoeObservables.registerCb(OBS_KEYS.staffAdded, ->
-        displayCurrentState()
+        fetchStaffs(vm.staff.nbItems, vm.staff.offset)
       )
       # Notify me if the list changes
       MnoeObservables.registerCb(OBS_KEYS.staffChanged, ->
-        displayCurrentState()
+        fetchStaffs(vm.staff.nbItems, vm.staff.offset)
       )
     )
     return

--- a/frontend-admin/src/app/index.constants.coffee
+++ b/frontend-admin/src/app/index.constants.coffee
@@ -1,6 +1,7 @@
 @App
   .constant('USER_ROLES', ['Member', 'Power User', 'Admin', 'Super Admin'])
-  .constant('ADMIN_ROLES', ['Admin', 'Staff'])
+  .constant('ADMIN_ROLES', ['admin', 'staff'])  # Must be lower case
+  .constant('STAFF_PAGE_AUTH', ['admin'])
   .constant('OBS_KEYS', {
     userChanged: 'userListChanged',
     staffChanged: 'staffListChanged',

--- a/frontend-admin/src/app/views/dashboard.controller.coffee
+++ b/frontend-admin/src/app/views/dashboard.controller.coffee
@@ -1,8 +1,9 @@
-@App.controller 'DashboardController', ($scope, $cookies, $sce, MnoeMarketplace, MnoErrorsHandler) ->
+@App.controller 'DashboardController', ($scope, $cookies, $sce, MnoeMarketplace, MnoErrorsHandler, MnoeCurrentUser, STAFF_PAGE_AUTH) ->
   'ngInject'
   main = this
 
   main.errorHandler = MnoErrorsHandler
+  main.staffPageAuthorized = STAFF_PAGE_AUTH
 
   main.trustSrc = (src) ->
     $sce.trustAsResourceUrl(src)
@@ -31,5 +32,10 @@
   # Preload data to be reused in the app
   # Marketplace is cached
   # MnoeMarketplace.getApps()
+
+  MnoeCurrentUser.getAdminRole().then(
+    # Display the layout
+    main.user = MnoeCurrentUser.user
+  )
 
   return

--- a/frontend-admin/src/app/views/dashboard.layout.html
+++ b/frontend-admin/src/app/views/dashboard.layout.html
@@ -19,7 +19,7 @@
       <li class="sidebar-list">
         <a href="#/customers">Customers <span class="menu-icon fa fa-users"></span></a>
       </li>
-      <li class="sidebar-list">
+      <li class="sidebar-list" ng-show="main.staffPageAuthorized.indexOf(main.user.admin_role)!=-1">
         <a href="#/staff">Staff <span class="menu-icon fa fa-wrench"></span></a>
       </li>
     </ul>

--- a/frontend-admin/src/app/views/staff/create-staff-modal/create-staff.controller.coffee
+++ b/frontend-admin/src/app/views/staff/create-staff-modal/create-staff.controller.coffee
@@ -8,10 +8,8 @@
     vm.isLoading = true
     MnoeUsers.addStaff(vm.user).then(
       (success) ->
-
         # Send an email to the new staff
         sendConfirmationEmail(vm.user)
-
       (error) ->
         toastr.error("An error occurred while adding #{vm.user.name} #{vm.user.surname}.")
         $log.error("An error occurred:", error)
@@ -24,10 +22,8 @@
     MnoeUsers.sendSignupEmail(user.email).then(
       (success) ->
         toastr.success("#{user.name} #{user.surname} has been successfully added.")
-
         # Close the modal returning the item to the parent window
         $uibModalInstance.close(success.data)
-
       (error) ->
         toastr.error("An error occurred while sending an email to #{user.email}.")
         $log.error("An error occurred:", error)

--- a/frontend-admin/src/app/views/staff/create-staff-modal/create-staff.controller.coffee
+++ b/frontend-admin/src/app/views/staff/create-staff-modal/create-staff.controller.coffee
@@ -8,9 +8,10 @@
     vm.isLoading = true
     MnoeUsers.addStaff(vm.user).then(
       (success) ->
-        toastr.success("#{vm.user.name} #{vm.user.surname} has been successfully added.")
-        # Close the modal returning the item to the parent window
-        $uibModalInstance.close(success.data)
+
+        # Send an email to the new staff
+        sendConfirmationEmail(vm.user)
+
       (error) ->
         toastr.error("An error occurred while adding #{vm.user.name} #{vm.user.surname}.")
         $log.error("An error occurred:", error)
@@ -18,5 +19,26 @@
 
   vm.onCancel = () ->
     $uibModalInstance.dismiss('cancel')
+
+  sendConfirmationEmail = (user) ->
+    MnoeUsers.sendSignupEmail(user.email).then(
+      (success) ->
+        toastr.success("#{user.name} #{user.surname} has been successfully added.")
+
+        # Close the modal returning the item to the parent window
+        $uibModalInstance.close(success.data)
+
+      (error) ->
+        toastr.error("An error occurred while sending an email to #{user.email}.")
+        $log.error("An error occurred:", error)
+
+        # Remove the staff that has been added
+        MnoeUsers.removeStaff(vm.user.id).then(
+          (success) ->
+          (error) ->
+            toastr.error("An error occurred while deleting the user.")
+            $log.error("An error occurred:", error)
+        )
+    )
 
   return


### PR DESCRIPTION
### Bugs Fix
- I fixed a bug stopping the page to reload when an action was done on a staff (update, delete, add).
- Sends an invitation email when a staff is added so that he connects.

### Improvements
- Stopped non admin "admin" to access the staff page.

### To Do
- Make sure that the back-end stops staff to change admin_role.
- Brings a new staff straight away to the admin platform and not to the enterprise dashboard..