### PR TITLE
[MNOE-106] Admin Panel Improvements

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
@@ -40,10 +40,14 @@ module MnoEnterprise
 
     # PATCH /mnoe/jpi/v1/admin/users/:id
     def update
-      @user = MnoEnterprise::User.find(params[:id])
-      @user.update(user_params)
+      if current_user.admin_role == "admin"
+        @user = MnoEnterprise::User.find(params[:id])
+        @user.update(user_params)
 
-      render :show
+        render :show
+      else
+        render :index, status: :unauthorized
+      end
     end
 
     # DELETE /mnoe/jpi/v1/admin/users/1

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -98,8 +98,12 @@ module MnoEnterprise
     # Redirect to previous url and reset it
     def after_sign_in_path_for(resource)
       previous_url = session.delete(:previous_url)
-      url = MnoEnterprise.router.dashboard_path || main_app.root_url
-      return (return_to_url(resource) || previous_url || url)
+      default_url = if resource.respond_to?(:admin_role) && resource.admin_role.present?
+        '/admin/'
+      else
+        MnoEnterprise.router.dashboard_path || main_app.root_url
+      end
+      return (return_to_url(resource) || previous_url || default_url)
     end
 
     # Some controllers needs to redirect to 'MySpace' which breaks if you dont use mnoe-frontend

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -99,7 +99,7 @@ module MnoEnterprise
     def after_sign_in_path_for(resource)
       previous_url = session.delete(:previous_url)
       default_url = if resource.respond_to?(:admin_role) && resource.admin_role.present?
-        '/admin/'
+        MnoEnterprise.router.admin_path
       else
         MnoEnterprise.router.dashboard_path || main_app.root_url
       end

--- a/core/lib/mno_enterprise/core.rb
+++ b/core/lib/mno_enterprise/core.rb
@@ -53,6 +53,10 @@ module MnoEnterprise
       @terms_url || '#'
     end
 
+    def admin_path
+      @admin_path || '/admin/'
+    end
+
     def launch_url(id,opts = {})
       host_url("/launch/#{id}",opts)
     end

--- a/core/lib/mno_enterprise/testing_support/factories/users.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/users.rb
@@ -4,7 +4,7 @@
 # Use as such: build(:api_user)
 # See http://stackoverflow.com/questions/10032760/how-to-define-an-array-hash-in-factory-girl
 FactoryGirl.define do
-  
+
   factory :user, class: MnoEnterprise::User do
     sequence(:id)
     sequence(:uid) { |n| "usr-fda9#{n}" }
@@ -20,28 +20,32 @@ FactoryGirl.define do
     created_at 2.days.ago
     updated_at 2.days.ago
     sso_session "1fdd5sf5a73D7sd1as2a4sd541"
-    admin_role false
+    admin_role nil
 
     confirmation_sent_at 2.days.ago
     confirmation_token "wky763pGjtzWR7dP44PD"
     confirmed_at 1.days.ago
-    
+
     trait :unconfirmed do
       confirmed_at nil
     end
 
     trait :admin do
-      admin_role true
+      admin_role 'admin'
+    end
+
+    trait :staff do
+      admin_role 'staff'
     end
 
     trait :with_deletion_request do
       deletion_request { build(:deletion_request).attributes }
     end
-    
+
     trait :with_organizations do
       organizations { [build(:organization).attributes] }
     end
-    
+
     # Properly build the resource with Her
     initialize_with { new(attributes).tap { |e| e.clear_attribute_changes! } }
   end

--- a/core/spec/controllers/mno_enterprise/application_controller_spec.rb
+++ b/core/spec/controllers/mno_enterprise/application_controller_spec.rb
@@ -19,7 +19,7 @@ module MnoEnterprise
       it { expect(controller.add_param_to_fragment('/#/platform/dashboard/he/43?en=690', 'foo', [{msg: 'yolo'}])).to eq('/#/platform/dashboard/he/43?en=690&foo=%7B%3Amsg%3D%3E%22yolo%22%7D') }
     end
 
-    describe '#after_sign_in_path_for' dos
+    describe '#after_sign_in_path_for' do
       before { @request.env["devise.mapping"] = Devise.mappings[:user] }
 
       it { expect(controller.after_sign_in_path_for(User.new())).to eq('/dashboard/') }

--- a/core/spec/controllers/mno_enterprise/application_controller_spec.rb
+++ b/core/spec/controllers/mno_enterprise/application_controller_spec.rb
@@ -2,14 +2,30 @@ require 'rails_helper'
 
 module MnoEnterprise
   describe ApplicationController, type: :controller do
-    describe '#add_param_to_fragment' do
-      let(:controller) { MnoEnterprise::ApplicationController.new }
+    # create an anonymous subclass of ApplicationController to expose protected methods
+    controller(MnoEnterprise::ApplicationController) do
+      def after_sign_in_path_for(resource)
+        super
+      end
+      def add_param_to_fragment(url, param_name, param_value)
+        super
+      end
+    end
 
-      it { expect(subject.send(:add_param_to_fragment, '/#/platform/accounts', 'foo', 'bar')).to eq('/#/platform/accounts?foo=bar') }
-      it { expect(subject.send(:add_param_to_fragment, '/', 'foo', 'bar')).to eq('/#?foo=bar') }
-      it { expect(subject.send(:add_param_to_fragment, '/#/platform/dashboard/he/43?en=690', 'foo', 'bar')).to eq('/#/platform/dashboard/he/43?en=690&foo=bar') }
-      it { expect(subject.send(:add_param_to_fragment, '/#/platform/dashboard/he/43?en=690', 'foo', [{msg: 'yolo'}])).to eq('/#/platform/dashboard/he/43?en=690&foo=%7B%3Amsg%3D%3E%22yolo%22%7D') }
+    describe '#add_param_to_fragment' do
+      it { expect(controller.add_param_to_fragment('/#/platform/accounts', 'foo', 'bar')).to eq('/#/platform/accounts?foo=bar') }
+      it { expect(controller.add_param_to_fragment('/', 'foo', 'bar')).to eq('/#?foo=bar') }
+      it { expect(controller.add_param_to_fragment('/#/platform/dashboard/he/43?en=690', 'foo', 'bar')).to eq('/#/platform/dashboard/he/43?en=690&foo=bar') }
+      it { expect(controller.add_param_to_fragment('/#/platform/dashboard/he/43?en=690', 'foo', [{msg: 'yolo'}])).to eq('/#/platform/dashboard/he/43?en=690&foo=%7B%3Amsg%3D%3E%22yolo%22%7D') }
+    end
+
+    describe '#after_sign_in_path_for' dos
+      before { @request.env["devise.mapping"] = Devise.mappings[:user] }
+
+      it { expect(controller.after_sign_in_path_for(User.new())).to eq('/dashboard/') }
+      it { expect(controller.after_sign_in_path_for(User.new(admin_role: "staff"))).to eq('/admin/') }
+      it { expect(controller.after_sign_in_path_for(User.new(admin_role: ""))).to eq('/dashboard/') }
+      it { expect(controller.after_sign_in_path_for(User.new(admin_role: "admin"))).to eq('/admin/') }
     end
   end
-
 end

--- a/core/spec/controllers/mno_enterprise/i18n_spec.rb
+++ b/core/spec/controllers/mno_enterprise/i18n_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module MnoEnterprise
-  describe ApplicationController, type: :controller do
+  describe 'ApplicationController I18n', type: :controller do
     # Anonymous controller
     controller do
       include MnoEnterprise::Concerns::Controllers::I18n

--- a/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
@@ -7,7 +7,7 @@
 # fork of the upstream library
 
 
-@App.service 'MnoeCurrentUser', (MnoeApiSvc, $window, $state) ->
+@App.service 'MnoeCurrentUser', (MnoeApiSvc, $window, $state, $q) ->
   _self = @
 
   # Store the current_user promise
@@ -26,5 +26,15 @@
         angular.copy(adminRole, _self.user)
         response
     )
+
+  @skipIfNotAdmin = () ->
+    if _self.user.admin_role? && _self.user.admin_role == 'admin'
+      return $q.resolve()
+    else
+      $timeout(->
+        # Runs after the authentication promise has been rejected.
+        $state.go('dashboard.home')
+      )
+      $q.reject()
 
   return @

--- a/frontend-admin/src/app/index.route.coffee
+++ b/frontend-admin/src/app/index.route.coffee
@@ -43,6 +43,8 @@
       controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'Staff'
+      resolve:
+        skip: (MnoeCurrentUser) -> MnoeCurrentUser.skipIfNotAdmin()
     .state 'dashboard.customers',
       url: '/customers'
       templateUrl: 'app/views/customers/customers.html'


### PR DESCRIPTION
Same as #50 but merging to 3.1

- Make sure that the back-end stops staff to change admin_role.
- Brings a new staff straight away to the admin platform and not to the enterprise dashboard

