### PR TITLE
Transmit parameters  given to launch in the redirection

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -25,7 +25,7 @@ module MnoEnterprise::Concerns::Controllers::PagesController
   def launch
     app = MnoEnterprise::AppInstance.find_by(uid: params[:id])
     MnoEnterprise::EventLogger.info('app_launch', current_user.id, 'App launched', app.name, app)
-    redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.merge(request.query_parameters))
+    redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
   end
 
   # GET /loading/:id

--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -24,8 +24,8 @@ module MnoEnterprise::Concerns::Controllers::PagesController
   # mandatory as Mno Enterprise will do it anyway
   def launch
     app = MnoEnterprise::AppInstance.find_by(uid: params[:id])
-    MnoEnterprise::EventLogger.info('app_launch', current_user.id, "App launched", app.name, app)
-    redirect_to MnoEnterprise.router.launch_url(params[:id], wtk: MnoEnterprise.jwt(user_id: current_user.uid))
+    MnoEnterprise::EventLogger.info('app_launch', current_user.id, 'App launched', app.name, app)
+    redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.merge(request.query_parameters))
   end
 
   # GET /loading/:id

--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -27,6 +27,19 @@ module MnoEnterprise
       end
     end
 
+    describe 'GET #launch with parameters' do
+      let(:app_instance) { build(:app_instance) }
+      before { sign_in user }
+      subject { get :launch, id: app_instance.uid, specific_parameters: 'specific_parameters_value' }
+
+      it_behaves_like "a navigatable protected user action"
+
+      it 'redirect to the mno enterprise launch page with a web token' do
+        subject
+        expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific_parameters_value'))
+      end
+    end
+
     describe 'GET #app_access_unauthorized' do
       subject { get :app_access_unauthorized }
       before { subject }

--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -34,7 +34,7 @@ module MnoEnterprise
 
       it_behaves_like "a navigatable protected user action"
 
-      it 'redirect to the mno enterprise launch page with a web token' do
+      it 'redirects to the mno enterprise launch page with a web token and extra params' do
         subject
         expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific_parameters_value'))
       end


### PR DESCRIPTION
Add-on (Applications using the connector framework) needs to transmit parameters for example /mnoe/launch/cld-9pfh?settings=true
These parameters needs to be transfered to the MnoEnterprise.router.launch_url