### PR TITLE
[MNOE-125] Fix filtering on empty array

### DIFF
--- a/core/lib/her_extension/model/relation.rb
+++ b/core/lib/her_extension/model/relation.rb
@@ -26,6 +26,9 @@ module Her
       # Use filter instead of raw parameters
       def where(params = {})
         return self if !params || params.empty?
+        # If a value is an empty array, it'll be excluded when calling params.to_query, so convert it to nil instead
+        params.each { |k, v| params[k] = v.presence if v.is_a?(Array) }
+
         self.params[:filter] ||= {}
         self.params[:filter].merge!(params)
         self

--- a/core/spec/lib/her_extension/model/relation_spec.rb
+++ b/core/spec/lib/her_extension/model/relation_spec.rb
@@ -3,5 +3,19 @@ require 'rails_helper'
 module MnoEnterprise
   RSpec.describe Her::Model::Relation do
     pending "add specs for Her::Model::Relation monkey patch: #{__FILE__}"
+
+    let(:dummy_class) { Class.new { include Her::Model } }
+
+    describe '.where' do
+      it 'adds the filter to params[:filter]' do
+        rel = Her::Model::Relation.new(dummy_class).where('uid.in' => [1, 2], 'foo' => 'bar')
+        expect(rel.params[:filter]).to eq('uid.in' => [1, 2], 'foo' => 'bar')
+      end
+
+      it 'replaces empty array values with nil' do
+        rel = Her::Model::Relation.new(dummy_class).where('id.in' => [])
+        expect(rel.params[:filter]).to eq('id.in' => nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
If a filter is an empty array, it'll be excluded when calling
`params.to_query`, so convert it to nil instead.

eg: where('id.in' => []) => {'id.in' => nil}