### PR TITLE
[MNOE-137] Add Her middleware to handle errors

### DIFF
--- a/core/lib/her_extension/middleware/mnoe_raise_error.rb
+++ b/core/lib/her_extension/middleware/mnoe_raise_error.rb
@@ -1,0 +1,21 @@
+module Her
+  module Middleware
+    # This middleware will raise errors based on the response status
+    # Same as Faraday::Response::RaiseError, except it will catch specific
+    # errors codes rather than everything in 400..600
+    class MnoeRaiseError < Faraday::Response::RaiseError
+      def on_complete(env)
+        case env[:status]
+        when 407
+          # mimic the behavior that we get with proxy requests with HTTPS
+          raise Faraday::Error::ConnectionFailed,
+                %(407 "Proxy Authentication Required ")
+        when 502..504
+          raise Faraday::Error::ConnectionFailed, response_values(env)
+        when 401, 500
+          raise Faraday::Error::ClientError, response_values(env)
+        end
+      end
+    end
+  end
+end

--- a/core/lib/mno_enterprise/core.rb
+++ b/core/lib/mno_enterprise/core.rb
@@ -18,6 +18,7 @@ require "her_extension/model/associations/association"
 require "her_extension/model/associations/association_proxy"
 require "her_extension/model/associations/has_many_association"
 require "her_extension/middleware/mnoe_api_v1_parse_json"
+require "her_extension/middleware/mnoe_raise_error"
 require "faraday_middleware"
 require "mno_enterprise/engine"
 
@@ -266,6 +267,9 @@ module MnoEnterprise
 
         # Adapter
         c.use Faraday::Adapter::NetHttpNoProxy
+
+        # Error Handling
+        c.use Her::Middleware::MnoeRaiseError
       end
     end
 end

--- a/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
+++ b/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
@@ -124,7 +124,8 @@ module MnoEnterpriseApiTestHelper
 
         # Response
         c.use Her::Middleware::MnoeApiV1ParseJson
-      
+        c.use Her::Middleware::MnoeRaiseError
+
         # Add stubs on the test adapter
         c.use MnoeFaradayTestAdapter do |receiver|
           @_stub_list.each do |key,stub|

--- a/core/spec/models/mno_enterprise/base_resource_spec.rb
+++ b/core/spec/models/mno_enterprise/base_resource_spec.rb
@@ -2,6 +2,28 @@ require 'rails_helper'
 
 module MnoEnterprise
   RSpec.describe BaseResource, type: :model do
+    describe 'Error Handling' do
+      class Test < BaseResource; end
+
+      context 'Connection Errors' do
+        ((502..504).to_a<<407).each do |code|
+          it "handles #{code} error" do
+            api_stub_for(get: "/tests/1", code: code)
+            expect { Test.find(1) }.to raise_error(Faraday::ConnectionFailed)
+          end
+        end
+      end
+
+      context 'Server Errors' do
+        [401, 500].each do |code|
+          it "handles #{code} error" do
+            api_stub_for(get: "/tests/1", code: code)
+            expect { Test.find(1) }.to raise_error(Faraday::Error::ClientError)
+          end
+        end
+      end
+    end
+
     describe '#cache_key' do
       context 'for existing record' do
         let(:user) { build(:user) }


### PR DESCRIPTION
Handle connection and server errors

Mnoe api call will now raise `Faraday::Error::ConnectionFailed` or `Faraday::Error::ClientError` instead of returning `nil`

When the call is valid but the resource is not found it'll still return `nil` to keep the same behavior.