### PR TITLE
[MNOE-149] Allow impersonate_redirect_uri

### DIFF
--- a/api/app/controllers/mno_enterprise/impersonate_controller.rb
+++ b/api/app/controllers/mno_enterprise/impersonate_controller.rb
@@ -8,6 +8,7 @@ module MnoEnterprise
     # Perform the user impersonate action
     # GET /impersonate/user/123
     def create
+      session[:impersonator_redirect_path] = params[:redirect_path].presence
       @user = MnoEnterprise::User.find(params[:user_id])
       if @user.present?
         impersonate(@user)
@@ -31,7 +32,7 @@ module MnoEnterprise
       else
         flash[:notice] = "You weren't impersonating anyone"
       end
-      redirect_to '/admin/'
+      redirect_to session.delete(:impersonator_redirect_path).presence || '/admin/'
     end
 
     private

--- a/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
@@ -22,8 +22,6 @@ module MnoEnterprise
       end
 
       describe "#create" do
-
-
         it do
           expect(controller.current_user.id).to eq(user.id)
           get :create, user_id: user2.id
@@ -32,17 +30,24 @@ module MnoEnterprise
       end
 
       describe "#destroy" do
-        before do
-          get :create, user_id: user2.id
-        end
-
-        it { expect(controller.current_user.id).to eq(user2.id) }
-
         subject { get :destroy }
 
-        it { subject; expect(controller.current_user.id).to eq(user.id) }
+        context 'without redirect_path' do
+          before { get :create, user_id: user2.id }
+
+          it { expect(controller.current_user.id).to eq(user2.id) }
+
+          it { subject; expect(controller.current_user.id).to eq(user.id) }
+
+          it { is_expected.to redirect_to('/admin/') }
+        end
+
+        context 'with a redirect_path' do
+          before { get :create, user_id: user2.id, redirect_path: '/admin/redirect#path' }
+
+          it { is_expected.to redirect_to('/admin/redirect#path') }
+        end
       end
     end
   end
-
 end


### PR DESCRIPTION
Impersonate now takes a redirect_uri parameters which will be the url
the admin is redirected to when exiting impersonation.