### PR TITLE
[MNO-271] Add support for Intercom secure mode

### DIFF
--- a/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
@@ -17,7 +17,11 @@ json.cache! ['v1', @user.cache_key] do
     if current_impersonator
       json.current_impersonator true
     end
-    
+
+    if @user.respond_to?(:intercom_user_hash)
+      json.user_hash @user.intercom_user_hash
+    end
+
     # Embed association if user is persisted
     if @user.id
       json.organizations do

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -39,6 +39,7 @@
 
 module MnoEnterprise
   class User < BaseResource
+    include MnoEnterprise::Concerns::Models::IntercomUser
     extend Devise::Models
     
     # Note: password and encrypted_password are write-only attributes and are never returned by

--- a/core/lib/mno_enterprise/concerns/models/intercom_user.rb
+++ b/core/lib/mno_enterprise/concerns/models/intercom_user.rb
@@ -9,11 +9,6 @@ module MnoEnterprise::Concerns::Models::IntercomUser
   # 'included do' causes the included code to be evaluated in the
   # context where it is included rather than being executed in the module's context
   included do
-    # Return intercom user hash
-    # This is used in secure mode
-    def intercom_user_hash
-      OpenSSL::HMAC.hexdigest('sha256', MnoEnterprise.intercom_api_secret, (self.id || self.email).to_s)
-    end
   end
 
   #==================================================================
@@ -25,4 +20,9 @@ module MnoEnterprise::Concerns::Models::IntercomUser
   #==================================================================
   # Instance methods
   #==================================================================
+  # Return intercom user hash
+  # This is used in secure mode
+  def intercom_user_hash
+    OpenSSL::HMAC.hexdigest('sha256', MnoEnterprise.intercom_api_secret, (self.id || self.email).to_s)
+  end
 end

--- a/core/lib/mno_enterprise/concerns/models/intercom_user.rb
+++ b/core/lib/mno_enterprise/concerns/models/intercom_user.rb
@@ -1,0 +1,33 @@
+require 'openssl'
+
+module MnoEnterprise::Concerns::Models::IntercomUser
+  extend ActiveSupport::Concern
+
+  #==================================================================
+  # Included methods
+  #==================================================================
+  # 'included do' causes the included code to be evaluated in the
+  # context where it is included rather than being executed in the module's context
+  included do
+    if MnoEnterprise.intercom_enabled?
+      # Return intercom user hash
+      # This is used in secure mode
+      def intercom_user_hash
+        OpenSSL::HMAC.hexdigest('sha256', MnoEnterprise.intercom_api_secret, (self.id || self.email).to_s)
+      end
+    end
+  end
+
+  #==================================================================
+  # Class methods
+  #==================================================================
+  module ClassMethods
+    # def some_class_method
+    #   'some text'
+    # end
+  end
+
+  #==================================================================
+  # Instance methods
+  #==================================================================
+end

--- a/core/spec/models/mno_enterprise/user_spec.rb
+++ b/core/spec/models/mno_enterprise/user_spec.rb
@@ -40,19 +40,32 @@ module MnoEnterprise
     end
 
     describe :intercom_user_hash do
-      before { allow(MnoEnterprise).to receive(:intercom_enabled?).and_return(true) }
-      before { allow(MnoEnterprise).to receive(:intercom_api_secret).and_return('mysecret') }
-
-      # Reload User class to include IntercomUser concern
-      before do
-        MnoEnterprise.send(:remove_const, :User)
-        load "#{Rails.root}/../../app/models/mno_enterprise/user.rb"
-      end
-
       let(:user) { MnoEnterprise::User.new(email: 'admin@example.com') }
 
-      it 'returns the user intercom hash' do
-        expect(user.intercom_user_hash).not_to be_nil
+      context 'without Intercom' do
+        # default
+        it { expect(user).not_to respond_to(:intercom_user_hash) }
+      end
+
+      context 'with Intercom' do
+        before do
+          allow(MnoEnterprise).to receive(:intercom_enabled?).and_return(true)
+          allow(MnoEnterprise).to receive(:intercom_api_secret).and_return('mysecret')
+
+          # Reload User class to include IntercomUser concern
+          MnoEnterprise.send(:remove_const, :User)
+          load 'app/models/mno_enterprise/user.rb'
+        end
+
+        it 'returns the user intercom hash' do
+          expect(user.intercom_user_hash).not_to be_nil
+        end
+
+        after do
+          # Reset to default
+          MnoEnterprise.send(:remove_const, :User)
+          load 'app/models/mno_enterprise/user.rb'
+        end
       end
     end
   end


### PR DESCRIPTION
Intercom need a server side generated HMAC of the user_id or email when
secure mode is enabled.

See: https://docs.intercom.com/configure-intercom-for-your-product-or-site/staying-secure/enable-secure-mode-on-your-web-product