### PR TITLE
Fix time-dependent specs

### DIFF
--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -5,6 +5,10 @@ module MnoEnterprise
     render_views
     routes { MnoEnterprise::Engine.routes }
 
+    # Freeze time (JWT are time dependent)
+    before { Timecop.freeze }
+    after { Timecop.return }
+
     let(:user) { build(:user) }
     let(:app_instance) { build(:app_instance) }
 

--- a/api/spec/controllers/mno_enterprise/webhook/o_auth_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/webhook/o_auth_controller_spec.rb
@@ -9,6 +9,10 @@ module MnoEnterprise
     render_views
     routes { MnoEnterprise::Engine.routes }
 
+    # Freeze time (JWT are time dependent)
+    before { Timecop.freeze }
+    after { Timecop.return }
+
     # Stub controller ability
     let!(:ability) { stub_ability }
     let(:extra_params) { {some: 'param'} }
@@ -33,7 +37,7 @@ module MnoEnterprise
       it_behaves_like 'a user protected resource'
 
       it { subject; expect(response).to be_success }
-      it { Timecop.freeze { subject; expect(assigns(:redirect_to)).to eq(redirect_url) } }
+      it { subject; expect(assigns(:redirect_to)).to eq(redirect_url) }
 
       Webhook::OAuthController::PROVIDERS_WITH_OPTIONS.each do |provider|
         describe "#{provider.capitalize} provider" do

--- a/frontend/spec/controllers/mno_enterprise/webhook/o_auth_controller_spec.rb
+++ b/frontend/spec/controllers/mno_enterprise/webhook/o_auth_controller_spec.rb
@@ -6,6 +6,10 @@ module MnoEnterprise
     render_views
     routes { MnoEnterprise::Engine.routes }
 
+    # Freeze time (JWT are time dependent)
+    before { Timecop.freeze }
+    after { Timecop.return }
+
     # Stub controller ability
     let!(:ability) { stub_ability }
     let(:extra_params) { {some: 'param'} }
@@ -30,7 +34,7 @@ module MnoEnterprise
       it_behaves_like "a user protected resource"
 
       it { subject; expect(response).to be_success }
-      it { Timecop.freeze { subject; expect(assigns(:redirect_to)).to eq(redirect_url) } }
+      it { subject; expect(assigns(:redirect_to)).to eq(redirect_url) }
 
       Webhook::OAuthController::PROVIDERS_WITH_OPTIONS.each do |provider|
         describe "#{provider.capitalize} provider" do
@@ -39,7 +43,7 @@ module MnoEnterprise
 
           context 'with perform=true' do
             let(:extra_params) { {perform: true} }
-            it { Timecop.freeze { subject; expect(assigns(:redirect_to)).to eq(redirect_url) } }
+            it { subject; expect(assigns(:redirect_to)).to eq(redirect_url) }
           end
         end
       end


### PR DESCRIPTION
Freeze time when generating JWT as they are time-dependent.