### PR TITLE
[MNOE-177] UI: SignUp Page: Error message displayed when email is already registered

### DIFF
--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -56,7 +56,6 @@ module MnoEnterprise
     #================================
     # Validation
     #================================
-    validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
 
     if Devise.password_regex
       validates :password, format: { with: Devise.password_regex, message: Devise.password_regex_message }, if: :password_required?


### PR DESCRIPTION
` validates_uniqueness_of email ` was useless. The User Model is using the devise option validatable which  performs the uniqueness validation

 http://www.rubydoc.info/github/plataformatec/devise/Devise/Models/Validatable
 http://stackoverflow.com/questions/13897844/how-to-remove-duplicate-validation-errors