### PR TITLE
[Perf] Add AssociationProxy#loaded?

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
@@ -166,7 +166,15 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::OrganizationsController
 
   protected
     def organization
-      @organization ||= current_user.organizations.to_a.find{ |o| o.id.to_s == params[:id].to_s }
+      @organization ||= begin
+        # Find in arrays if organizations have been fetched
+        # already. Perform remote query otherwise
+        if current_user.organizations.loaded?
+          current_user.organizations.to_a.find { |o| o.id.to_s == params[:id].to_s }
+        else
+          current_user.organizations.where(id: params[:id]).first
+        end
+      end
     end
 
     def organization_permitted_update_params

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -43,7 +43,9 @@ module MnoEnterprise
     let(:credit_card) { build(:credit_card, organization: organization) }
 
     before do
-      allow_any_instance_of(MnoEnterprise::User).to receive(:organizations).and_return([organization]) # ???
+      organizations = [organization]
+      allow(organizations).to receive(:loaded?).and_return(true)
+      allow_any_instance_of(MnoEnterprise::User).to receive(:organizations).and_return(organizations)
       api_stub_for(get: "/organizations/#{organization.id}/invoices", response: from_api([invoice]))
       api_stub_for(get: "/organizations", response: from_api([organization]))
       api_stub_for(get: "/organizations/#{organization.id}", response: from_api(organization))

--- a/api/spec/controllers/mno_enterprise/jpi/v1/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/organizations_controller_spec.rb
@@ -30,7 +30,12 @@ module MnoEnterprise
 
     # Stub organization + associations
     let(:organization) { build(:organization) }
-    before { allow_any_instance_of(MnoEnterprise::User).to receive(:organizations).and_return([organization]) }
+
+    before do
+      organizations = [organization]
+      allow(organizations).to receive(:loaded?).and_return(true)
+      allow_any_instance_of(MnoEnterprise::User).to receive(:organizations).and_return(organizations)
+    end
 
     before { api_stub_for(post: "/organizations", response: from_api(organization)) }
     before { api_stub_for(put: "/organizations/#{organization.id}", response: from_api(organization)) }

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -181,7 +181,7 @@ module MnoEnterprise
       # Find in arrays if organizations have been fetched
       # already. Perform remote query otherwise
       org = begin
-        if self.organizations.is_a?(Array)
+        if self.organizations.loaded?
           self.organizations.to_a.find { |e| e.id == organization.id }
         else
           self.organizations.where(id: organization.id).first

--- a/core/lib/her_extension/model/associations/association_proxy.rb
+++ b/core/lib/her_extension/model/associations/association_proxy.rb
@@ -3,24 +3,28 @@ module Her
   module Model
     module Associations
       class AssociationProxy < (ActiveSupport.const_defined?('ProxyObject') ? ActiveSupport::ProxyObject : ActiveSupport::BasicObject)
-        
+
         install_proxy_methods :association,
           :build, :create, :update, :destroy, :where, :find, :all, :assign_nested_attributes, :reload, :order, :order_by, :limit, :skip
-        
-        
+
+        # Returns true if the association has been loaded, otherwise false.
+        def loaded?
+          !!association.instance_variable_get('@cached_result')
+        end
+
         def method_missing(name, *args, &block)
           if :object_id == name # avoid redefining object_id
             return association.fetch.object_id
           end
-          
+
           # Check if a class scope has previously been defined
           begin
             if Relation.scopes.keys.grep(::Regexp.new(name.to_s)).any?
               return self.association.send(name,*args,&block)
             end
-          rescue ::NoMethodError => e     
+          rescue ::NoMethodError => e
           end
-          
+
           # create a proxy to the fetched object's method
           # https://github.com/remiprev/her/pull/377
           AssociationProxy.install_proxy_methods 'association.fetch', name


### PR DESCRIPTION
Allow to check when association is already loaded to avoid unnecessary
queries.

@alachaum @BrunoChauvet should we extract this pattern 
```ruby
if self.organizations.loaded?
  self.organizations.to_a.find { |e| e.id == organization.id }
else
  self.organizations.where(id: organization.id).first
end
```
to a method on the HasManyAssociation? or is it too specific?


