### PR TITLE
[PERF] Avoid duplicated requests on admin endpoints

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/audit_events_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/audit_events_controller.rb
@@ -1,6 +1,6 @@
 module MnoEnterprise
   class Jpi::V1::Admin::AuditEventsController < Jpi::V1::Admin::BaseResourceController
-    
+
     # GET /mnoe/jpi/v1/admin/audit_events
     def index
       @audit_events = MnoEnterprise::AuditEvent
@@ -8,7 +8,7 @@ module MnoEnterprise
       @audit_events = @audit_events.skip(params[:offset]) if params[:offset]
       @audit_events = @audit_events.order_by(params[:order_by]) if params[:order_by]
       @audit_events = @audit_events.where(params[:where]) if params[:where]
-      @audit_events = @audit_events.all
+      @audit_events = @audit_events.all.fetch
 
       response.headers['X-Total-Count'] = @audit_events.metadata[:pagination][:count]
     end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
@@ -8,7 +8,7 @@ module MnoEnterprise
       @organizations = @organizations.skip(params[:offset]) if params[:offset]
       @organizations = @organizations.order_by(params[:order_by]) if params[:order_by]
       @organizations = @organizations.where(params[:where]) if params[:where]
-      @organizations = @organizations.all
+      @organizations = @organizations.all.fetch
 
       response.headers['X-Total-Count'] = @organizations.metadata[:pagination][:count]
     end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
@@ -8,7 +8,7 @@ module MnoEnterprise
       @users = @users.skip(params[:offset]) if params[:offset]
       @users = @users.order_by(params[:order_by]) if params[:order_by]
       @users = @users.where(params[:where]) if params[:where]
-      @users = @users.all
+      @users = @users.all.fetch
 
       response.headers['X-Total-Count'] = @users.metadata[:pagination][:count]
     end


### PR DESCRIPTION
`@users.all` is a ProxyObject, so code like  `@users.metadata if
@users.respond_to?(:metadata)` will trigger 2 requests.
By calling `#fetch` we get a relation and only fetch it once.

Before:
```
Started GET "/mnoe/jpi/v1/admin/users?limit=10&offset=0&order_by=created_at.desc" for 127.0.0.1 at 2016-11-07 20:41:31 +1100
Processing by MnoEnterprise::Jpi::V1::Admin::UsersController#index as JSON
  Parameters: {"limit"=>"10", "offset"=>"0", "order_by"=>"created_at.desc"}
[localhost] GET /api/mnoe/v1/users/1235 (0.034 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.025 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.021 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.020 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.030 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.031 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.027 s)
Completed 200 OK in 1139ms (Views: 896.5ms | ActiveRecord: 0.0ms)
```

After:
```
Started GET "/mnoe/jpi/v1/admin/users?limit=10&offset=0&order_by=created_at.desc" for 127.0.0.1 at 2016-11-07 20:42:22 +1100
Processing by MnoEnterprise::Jpi::V1::Admin::UsersController#index as JSON
  Parameters: {"limit"=>"10", "offset"=>"0", "order_by"=>"created_at.desc"}
[localhost] GET /api/mnoe/v1/users/1235 (0.034 s)
[localhost] GET /api/mnoe/v1/users?limit=10&skip=0&sort%5B%5D=created_at.desc (0.023 s)
Completed 200 OK in 263ms (Views: 33.0ms | ActiveRecord: 0.0ms)
```

@alexnoox FYI