### PR TITLE
[MNOE-243] Disable I18n by default in generator

### DIFF
--- a/core/lib/generators/mno_enterprise/install/templates/config/initializers/mno_enterprise.rb
+++ b/core/lib/generators/mno_enterprise/install/templates/config/initializers/mno_enterprise.rb
@@ -63,7 +63,7 @@ MnoEnterprise.configure do |config|
   # I18n - Controls:
   #   - Routing in development
   #   - Filter and locale management in controllers
-  config.i18n_enabled = true
+  config.i18n_enabled = false
 
   #===============================================
   # Third Party Plugins


### PR DESCRIPTION
Disable I18n when generating a new project as it won't be needed for
most projects.
This can still be enabled in the initializer if needed.