### PR TITLE
[MNOE-250] Add conditional to disable protect_from_forgery

### DIFF
--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -1,6 +1,6 @@
 module MnoEnterprise
   class ApplicationController < ActionController::Base
-    protect_from_forgery
+    protect_from_forgery if: -> { MnoEnterprise.include_angular_csrf }
     include ApplicationHelper
     prepend_before_filter :skip_devise_trackable_on_xhr
 


### PR DESCRIPTION
Disabling the mno-enterprise AngularCSRF concern module is not enough for Impac! Workspace to fully work as `protect_from_forgery`([docs](http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html)) only allows GET requests.

@ouranos && @cesar-tonnoir please review.