### PR TITLE
[MNO-436] notify user of changes

### DIFF
--- a/api/config/initializers/devise.rb
+++ b/api/config/initializers/devise.rb
@@ -99,6 +99,9 @@ Devise.setup do |config|
   # Setup a pepper to generate the encrypted password.
   # config.pepper = '11ab398be280e434b1dc50197d359577c1bc52efd28a07d081e397c7c11dcf8d1ad80f40188d58421830c20351f5af8c1217b39397ca95ee33809c74b028972f'
 
+  # Send a notification email when the user's password is changed
+  config.send_password_change_notification = true
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/core/app/views/system_notifications/email-change.html.erb
+++ b/core/app/views/system_notifications/email-change.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  <%= stylesheet_link_tag('mno_enterprise/mail.css') %>
+</head>
+<body>
+<p class="header">
+  <%= image_tag('mno_enterprise/main-logo.png') %>
+</p>
+
+<p>Hi <%= @info[:first_name] %></p>
+
+<p>We received a request to change your email address in the platform to <%= @info[:unconfirmed_email] %>.</p>
+
+<p>If you did not request an email change, contact us.</p>
+
+<p>
+  Regards,<br/>
+  The Marketplace team
+</p>
+
+<p class="footer">
+  <%= @info[:company] %>
+</p>
+</body>
+</html>

--- a/core/app/views/system_notifications/email-change.text.erb
+++ b/core/app/views/system_notifications/email-change.text.erb
@@ -1,0 +1,10 @@
+Hi <%= @info[:first_name] %>
+=================================================================
+
+We received a request to change your email address in the platform to <%= @info[:unconfirmed_email] %>.
+
+If you did not request an email change, contact us.
+
+
+Regards,
+The Marketplace team

--- a/core/app/views/system_notifications/password-change.html.erb
+++ b/core/app/views/system_notifications/password-change.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  <%= stylesheet_link_tag('mno_enterprise/mail.css') %>
+</head>
+<body>
+<p class="header">
+  <%= image_tag('mno_enterprise/main-logo.png') %>
+</p>
+
+<p>Hi <%= @info[:first_name] %></p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>
+
+<p>
+  Regards,<br/>
+  The Marketplace team
+</p>
+
+<p class="footer">
+  <%= @info[:company] %>
+</p>
+</body>
+</html>

--- a/core/app/views/system_notifications/password-change.text.erb
+++ b/core/app/views/system_notifications/password-change.text.erb
@@ -1,0 +1,7 @@
+Hi <%= @info[:first_name] %>
+=================================================================
+
+We're contacting you to notify you that your password has been changed.
+
+Regards,
+The Marketplace team

--- a/core/app/views/system_notifications/reconfirmation-instructions.html.erb
+++ b/core/app/views/system_notifications/reconfirmation-instructions.html.erb
@@ -10,16 +10,18 @@
     </p>
 
     <p>Hi <%= @info[:first_name] %></p>
-     
-    <p>You have asked to change your email address in the platform. Please confirm this new email address by clicking on the following link</p>    
-     
+
+    <p>You have asked to change your email address in the platform. Please confirm this new email address by clicking on the following link</p>
+
     <a href="<%= @info[:confirmation_link] %>">Confirm my new email address</a>
-     
+
+    <p>If you did not ask for a modification just ignore this email.</p>
+
     <p>
       Regards,<br/>
       The Marketplace team
     </p>
-    
+
     <p class="footer">
       <%= @info[:company] %>
     </p>

--- a/core/app/views/system_notifications/reconfirmation-instructions.text.erb
+++ b/core/app/views/system_notifications/reconfirmation-instructions.text.erb
@@ -2,9 +2,10 @@ Hi <%= @info[:first_name] %>
 =================================================================
 
 You have asked to change your email address in the platform. Please confirm this new email address by clicking on the following link
- 
+
 <%= @info[:confirmation_link] %>
- 
+
+If you did not ask for a modification just ignore this email.
 
 Regards,
 The Marketplace team

--- a/core/spec/lib/devise/model/remote_authenticable_spec.rb
+++ b/core/spec/lib/devise/model/remote_authenticable_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Devise::Models::RemoteAuthenticatable < ActiveSupport::TestCase do
+  let(:user) { build(:user, email: 'test@maestrano.com', password: 'oldpass') }
+
+  before do
+    api_stub_for(put: "/users/#{user.id}", response: from_api(user))
+  end
+
+  describe 'Sends an email on password update' do
+    subject { user.update(updates) }
+
+    context 'when password change notifications are enabled' do
+      before { user.class.send_password_change_notification = true }
+
+      context 'when the password is changed' do
+        let(:updates) { {password: 'newpass', password_confirmation: 'newpass'} }
+
+        it 'sends an email' do
+          expect(user).to receive(:send_devise_notification).with(:password_change)
+          subject
+        end
+      end
+    end
+
+    context 'when password does not change notifications are disabled' do
+      before { user.class.send_password_change_notification = false }
+
+      context 'when the password is not updated' do
+        let(:updates) { {name: 'Bob'} }
+
+        it 'does not send an email' do
+          expect(user).not_to receive(:send_devise_notification)
+          subject
+        end
+      end
+
+      context 'when the password to change is invalid' do
+        let(:updates) { {password: '', password_confirmation: ''} }
+
+        it 'does not send an email' do
+          expect(user).not_to receive(:send_devise_notification)
+          subject
+        end
+      end
+
+      context 'when the password and its confirmation are different' do
+        let(:updates) { {password: 'password1', password_confirmation: 'another_password'} }
+
+        it 'does not send an email' do
+          expect(user).not_to receive(:send_devise_notification)
+          subject
+        end
+      end
+
+      context 'when the password is given without confirmation' do
+        let(:updates) { {password: 'new_password'} }
+
+        it 'does not send an email' do
+          expect(user).not_to receive(:send_devise_notification)
+          subject
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Notify users when password is updated.
- Sends an email to the old email when email changes.
- Sends an email to the new email when email changes.

Added specs (omg...)