### PR TITLE
Invoke locales:generate in frontend:build task

### DIFF
--- a/frontend/lib/tasks/mnoe_frontend_tasks.rake
+++ b/frontend/lib/tasks/mnoe_frontend_tasks.rake
@@ -117,6 +117,9 @@ namespace :mnoe do
       # Copy assets to public
       cp_r("#{frontend_tmp_folder}/dist/.","#{frontend_dist_folder}/")
 
+      # Generate locales
+      Rake::Task['mnoe:locales:generate'].invoke
+
       # Copy bower_components to public (used by live previewer)
       cp_r("#{frontend_tmp_folder}/bower_components","#{frontend_dist_folder}/")
 


### PR DESCRIPTION
Hey @ouranos I was getting sick of running `mnoe:frontend:update` and then `mnoe:locales:generate` so I thought I would add this as I can see no reason to not.. unless I'm missing something of course. I tried to write a spec for this but then realised there a lot of stuff that needs to be done because of yarn and such.. So seeing as there currently isn't a spec for this file currently I decided not to dive into that 😂 :beers: 