### PR TITLE
Bugfix for displaying the staff page

### DIFF
--- a/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
+++ b/frontend-admin/src/app/components/mnoe-api/admin/current-user.svc.coffee
@@ -18,17 +18,11 @@
   @user = {}
 
   # Get the current user profile
-  @getCurrentUser = ->
+  @getUser = ->
     return userPromise if userPromise?
     userPromise = MnoeApiSvc.one('current_user').get().then(
       (response) ->
-        user = {
-          name: response.data.name
-          surname: response.data.surname
-          adminRole: response.data.admin_role
-          email: response.data.email
-        }
-        angular.copy(user, _self.user)
+        angular.copy(response.data, _self.user)
         response
     )
 

--- a/frontend-admin/src/app/views/dashboard.controller.coffee
+++ b/frontend-admin/src/app/views/dashboard.controller.coffee
@@ -35,7 +35,7 @@
   # Marketplace is cached
   # MnoeMarketplace.getApps()
 
-  MnoeCurrentUser.getCurrentUser().then(
+  MnoeCurrentUser.getUser().then(
     # Display the layout
     main.user = MnoeCurrentUser.user
   )


### PR DESCRIPTION
@ouranos I introduced this bug only few days ago in the "admin panel improvements".
I use to have the user being only an admin role. 

```
adminRole = {admin_role: response.data.admin_role}
angular.copy(adminRole, _self.user)
```
which i didn't replaced well when I change it by user

```
user = {
  name: response.data.name
  surname: response.data.surname
  adminRole: response.data.admin_role
  email: response.data.email
}
angular.copy(user, _self.user)
```