### PR TITLE
[IMPAC-328] include params opts in kpis_controller #index

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -21,7 +21,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
   def index
     # Retrieve kpis templates from impac api.
     # TODO: improve request params to work for strong parameters
-    attrs = params.slice('metadata')
+    attrs = params.slice('metadata', 'opts')
     auth = { username: MnoEnterprise.tenant_id, password: MnoEnterprise.tenant_key }
 
     response = begin

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
@@ -31,8 +31,8 @@ module MnoEnterprise
     let(:alerts_hashes) { [from_api(alert)[:data]] }
 
     describe 'GET index' do
-      let(:params) { { 'metadata' => {'organization_ids' => ['some_id']} } }
-      subject { get :index, metadata: params['metadata'] }
+      let(:params) { { 'metadata' => {'organization_ids' => ['some_id']}, 'opts' => {'some' => 'opts'} } }
+      subject { get :index, metadata: params['metadata'], opts: params['opts'] }
 
       let(:impac_available_kpis) do
         [


### PR DESCRIPTION
@ouranos minor change to allow opts through the params for this proxied KPIs #index action. This is ultimately for passing `refresh_cache: true` to Impac! fixing IMPAC-328. Thanks