### PR TITLE
Devise - Do not load an ORM

### DIFF
--- a/api/config/initializers/devise.rb
+++ b/api/config/initializers/devise.rb
@@ -19,7 +19,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  # require 'devise/orm/active_record'
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is


### PR DESCRIPTION
We're not using ActiveRecord. This line causes ActiveRecord to be loaded
in the host app.