### PR TITLE
[MNOE-291] KPI & widget saving issues

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -119,17 +119,18 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
   private
 
     def dashboard
-      @dashboard ||= MnoEnterprise::Impac::Dashboard.find(params.require(:dashboard_id))
+      @dashboard ||= current_user.dashboards.find(params.require(:dashboard_id))
       return render_not_found('dashboard') unless @dashboard
       @dashboard
     end
 
-    def widget
-      return nil if (id = params.require(:kpi)[:widget_id]).blank?
-      @widget ||= MnoEnterprise::Impac::Widget.find(id)
-      return render_not_found('widget') unless @widget
-      @widget
-    end
+    # TODO: attach KPI onto widget capability
+    # def widget
+    #   return nil if (id = params.require(:kpi)[:widget_id]).blank?
+    #   @widget ||= MnoEnterprise::Impac::Widget.find(id)
+    #   return render_not_found('widget') unless @widget
+    #   @widget
+    # end
 
     def kpi
       @kpi ||= MnoEnterprise::Impac::Kpi.find(params[:id])

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
@@ -69,7 +69,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::WidgetsController
     end
 
     def widgets
-      @widgets ||= MnoEnterprise::Impac::Dashboard.find(params[:dashboard_id]).widgets
+      @widgets ||= current_user.dashboards.find(params[:dashboard_id]).widgets
     end
 
     def widget_create_params

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
@@ -79,7 +79,7 @@ module MnoEnterprise
       let (:kpi_targets) { {} }
 
       before do
-        api_stub_for(get: "/dashboards/#{dashboard.id}", response: from_api(dashboard))
+        api_stub_for(get: "/users/#{user.id}/dashboards/#{dashboard.id}", response: from_api(dashboard))
         api_stub_for(post: "/dashboards/#{dashboard.id}/kpis", response: from_api(kpi))
         api_stub_for(get: "/dashboards/#{dashboard.id}/kpis", response: from_api([]))
         api_stub_for(get: "/kpis/#{kpi.id}", response: from_api(kpi)) # kpi.reload


### PR DESCRIPTION
@ouranos this issue is pretty serious for Impac! as when you add widgets or KPIs to a Dashboard, the changes are not retrievable via mnoe until the dashboard object has reloaded.

@hedudelgado put forward a PR here: https://github.com/maestrano/mno-enterprise/pull/195, maybe you prefer this solution? 

@cesar-tonnoir @x4d3 