### PR TITLE
[MNOE-328] Add external_id and source tagging to Intercom

### DIFF
--- a/api/lib/mno_enterprise/intercom_events_listener.rb
+++ b/api/lib/mno_enterprise/intercom_events_listener.rb
@@ -65,6 +65,7 @@ module MnoEnterprise
         update_last_request_at: update_last_request_at
       }
       data[:custom_attributes][:phone]= user.phone if user.phone
+      data[:custom_attributes][:external_id]= user.external_id if user.external_id
 
       data[:companies] = user.organizations.map do |organization|
         {
@@ -81,6 +82,14 @@ module MnoEnterprise
         }
       end
       intercom.users.create(data)
+      tag_user(user)
+    end
+
+    # If a source is set, tag the user with it
+    def tag_user(user)
+      if user.meta_data && user.meta_data[:source].present?
+        intercom.tags.tag(name: user.meta_data[:source], users: [{user_id: user.id}])
+      end
     end
   end
 end

--- a/api/spec/lib/mno_enterprise/intercom_events_listener_spec.rb
+++ b/api/spec/lib/mno_enterprise/intercom_events_listener_spec.rb
@@ -12,20 +12,45 @@ module MnoEnterprise
       api_stub_for(get: "/organizations/#{organization.id}/app_instances", response: from_api([app_instance]))
     end
 
+    # Stub Intercom client
+    let(:tags) { double('tags') }
+    let(:events) { double('events') }
+    let(:users) { double('users') }
+    let(:client) { double('client', users: users, events: events, tags: tags) }
+    before do
+      expect(Intercom::Client).to receive(:new).with(app_id: MnoEnterprise.intercom_app_id, api_key: MnoEnterprise.intercom_api_key).and_return(client)
+    end
+
+    let(:expected_user_data) {
+      {
+        user_id: user.id,
+        name: [user.name, user.surname].join(' '),
+        email: user.email,
+        created_at: user.created_at.to_i,
+        last_seen_ip: user.last_sign_in_ip,
+        custom_attributes: {phone: user.phone},
+        update_last_request_at: true,
+        companies:[
+          {
+            company_id: organization.id,
+            name: organization.name,
+            created_at: organization.created_at.to_i,
+            custom_attributes: {
+              industry: organization.industry,
+              size: organization.size,
+              credit_card_details: organization.credit_card?,
+              app_count: organization.app_instances.count,
+              app_list: organization.app_instances.map { |app| app.name }.to_sentence
+            }
+          }
+        ]
+      }
+    }
 
     describe '#info' do
-      let(:events) { double('events') }
       context 'when the user already exist in intercom' do
-        before do
-          users = double('users')
-
-          client = double('client', users: users, events: events)
-          expect(Intercom::Client).to receive(:new).with(app_id: MnoEnterprise.intercom_app_id, api_key: MnoEnterprise.intercom_api_key).and_return(client)
-
-          expect(users).to receive(:find)
-        end
-
-        subject { MnoEnterprise::IntercomEventsListener.new }
+        before { allow(users).to receive(:find) }
+        subject { described_class.new }
 
         it 'add an event when an password is changed' do
           expect(events).to receive(:create).with(hash_including(email: user.email, user_id: user.id, event_name: 'user-update-password'))
@@ -45,44 +70,41 @@ module MnoEnterprise
       end
       context 'when the user does not exist in intercom' do
         before do
-          users = double('users')
-
-          client = double('client', users: users, events: events)
-          expect(Intercom::Client).to receive(:new).with(app_id: MnoEnterprise.intercom_app_id, api_key: MnoEnterprise.intercom_api_key).and_return(client)
-
-          expect(users).to receive(:find).and_raise(Intercom::ResourceNotFound.new('not found'))
-          user_data =        {
-            user_id: user.id,
-            name: [user.name, user.surname].join(' '),
-            email: user.email,
-            created_at: user.created_at.to_i,
-            last_seen_ip: user.last_sign_in_ip,
-            custom_attributes: {phone: user.phone},
-            update_last_request_at: true,
-            companies:[
-              {
-                company_id: organization.id,
-                name: organization.name,
-                created_at: organization.created_at.to_i,
-                custom_attributes: {
-                  industry: organization.industry,
-                  size: organization.size,
-                  credit_card_details: organization.credit_card?,
-                  app_count: organization.app_instances.count,
-                  app_list: organization.app_instances.map { |app| app.name }.to_sentence
-                }
-              }
-
-            ]
-          }
-          expect(users).to receive(:create).with(user_data)
+          allow(users).to receive(:find).and_raise(Intercom::ResourceNotFound.new('not found'))
+          expect(users).to receive(:create).with(expected_user_data)
         end
+
         it 'add an event when an password is changed' do
           expect(events).to receive(:create).with(hash_including(email: user.email, event_name: 'user-update-password'))
           subject.info('user_update_password', user.id, 'User password change', user.class.name, user.id, user.email)
         end
       end
+    end
 
+    describe '#update_intercom_user' do
+      subject { described_class.new.update_intercom_user(user) }
+      before { allow(users).to receive(:create) }
+
+      it 'updates the user' do
+        expect(users).to receive(:create).with(expected_user_data)
+        subject
+      end
+
+      context 'when the user has an external_id' do
+        before { user.external_id = '132456' }
+        it 'updates the user' do
+          expect(users).to receive(:create).with(hash_including(custom_attributes: { phone: user.phone, external_id: '132456' }))
+          subject
+        end
+      end
+
+      context 'when the user has a source' do
+        before { user.meta_data = {source: 'acme'}}
+        it 'tags the user' do
+          expect(tags).to receive(:tag).with(name: 'acme', users: [{user_id: user.id}])
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add the external_id field to Intercom if present.
Tag the user if a source is present.

See my comment on [MNO-512](https://maestrano.atlassian.net/browse/MNO-512) regarding the discrepancy.