### PR TITLE
Fix T&C page when no apps are present

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -59,9 +59,14 @@ module MnoEnterprise::Concerns::Controllers::PagesController
   def terms
     @meta[:title] = 'Terms of Use'
     @meta[:description] = 'Terms of Use'
-    ts = MnoEnterprise::App.order_by("updated_at.desc").first.updated_at
-    @apps = Rails.cache.fetch(['pages/terms/app-list', ts]) do
-      MnoEnterprise::App.order_by("name.ac").reject{|i| i.terms_url.blank?}
+
+    ts = MnoEnterprise::App.order_by("updated_at.desc").first.try(:updated_at)
+    @apps = if ts
+      Rails.cache.fetch(['pages/terms/app-list', ts]) do
+        MnoEnterprise::App.order_by("name.ac").reject{|i| i.terms_url.blank?}
+      end
+    else
+      []
     end
   end
 


### PR DESCRIPTION
@ouranos There were errors when trying to go to the terms of use page. After looking at the logs it seems the error happens whenever a marketplace does not have apps yet. I'm not sure if this is actually an issue though as a dashboard wouldn't really be functional without any applications anyway. Please review. 