### PR TITLE
[MNOE-443] Fix password change notification

### DIFF
--- a/core/lib/devise/models/remote_authenticatable.rb
+++ b/core/lib/devise/models/remote_authenticatable.rb
@@ -2,7 +2,7 @@ module Devise
   module Models
     module RemoteAuthenticatable
       extend ActiveSupport::Concern
- 
+
       #
       # Here you do the request to the external webservice
       #
@@ -44,7 +44,7 @@ module Devise
           end.tap {|r| r && r.clear_association_cache}
           record if record && record.authenticatable_salt == salt
         end
-        
+
         # Here you have to return and array with the data of your resource
         # that you want to serialize into the session
         #
@@ -60,8 +60,9 @@ module Devise
         # We want to send the notification once the password has changed but
         # we won't have access to dirty attributes.
         # Flag change before the model is saved.
+        # Do not send a notification at confirmation
         def track_password_changed
-          @password_changed = password_changed?
+          @password_changed = password_changed? && confirmed_at_was.present?
           true # before callback needs to return true to continue
         end
 

--- a/core/spec/lib/devise/model/remote_authenticable_spec.rb
+++ b/core/spec/lib/devise/model/remote_authenticable_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Devise::Models::RemoteAuthenticatable < ActiveSupport::TestCase d
     context 'when password change notifications are enabled' do
       before { user.class.send_password_change_notification = true }
 
+      context 'when the user is confirmed' do
+        let(:user) { build(:user, email: 'test@maestrano.com', password: 'oldpass', confirmed_at: nil) }
+        let(:updates) { {password: 'newpass', password_confirmation: 'newpass', confirmed_at: Time.current} }
+
+        it 'does not send an email' do
+          expect(user).not_to receive(:send_devise_notification)
+          subject
+        end
+      end
+
       context 'when the password is changed' do
         let(:updates) { {password: 'newpass', password_confirmation: 'newpass'} }
 


### PR DESCRIPTION
Do not send a notification when user sets their password during
confirmation step.