### PR TITLE
Add new fields and cache to the Marketplace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ script:
 - bundle exec rake spec
 rvm:
 - 2.1.10
-- 2.2.6
-- 2.3.3
+- 2.2.7
+- 2.3.4
 - 2.4.1
 addons:
   code_climate:

--- a/api/app/views/mno_enterprise/jpi/v1/marketplace/_app.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/marketplace/_app.json.jbuilder
@@ -1,7 +1,9 @@
 json.extract! app, :id, :nid, :name, :stack, :key_benefits, :categories, :tags, :tiny_description,
-              :testimonials, :pictures, :pricing_plans, :rank
+              :testimonials, :pictures, :pricing_plans, :rank, :support_url, :key_workflows, :key_features
 
 json.description markdown(app.sanitized_description)
+json.known_limitations markdown(app.known_limitations)
+json.getting_started markdown(app.getting_started)
 
 json.is_responsive app.responsive?
 json.is_star_ready app.star_ready?
@@ -12,6 +14,12 @@ json.multi_instantiable app.multi_instantiable
 json.subcategories app.subcategories
 json.average_rating app.average_rating
 json.running_instances_count app.running_instances_count
+
+json.shared_entities do
+  json.array! app.shared_entities do |shared_entity|
+    json.extract! shared_entity, :shared_entity_nid, :shared_entity_name, :write, :read
+  end
+end
 
 if app.logo
   json.logo app.logo.to_s

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
@@ -15,18 +15,30 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
   #==================================================================
   # GET /mnoe/mnoe/jpi/v1/marketplace
   def index
-    @apps = if MnoEnterprise.marketplace_listing
-              MnoEnterprise::App.where('nid.in' => MnoEnterprise.marketplace_listing).to_a
-            else
-              MnoEnterprise::App.all.to_a
-            end
-    @apps.sort_by! { |app| [app.rank ? 0 : 1 , app.rank] } # the nil ranks will appear at the end
-    @categories = MnoEnterprise::App.categories(@apps)
-    @categories.delete('Most Popular')
+    expires_in 0, public: true, must_revalidate: true
+    last_modified = app_relation.order_by('updated_at.desc').limit(1).first.updated_at
+
+    if stale?(last_modified: last_modified)
+      @apps = app_relation.to_a
+      @apps.sort_by! { |app| [app.rank ? 0 : 1 , app.rank] } # the nil ranks will appear at the end
+      @categories = MnoEnterprise::App.categories(@apps)
+      @categories.delete('Most Popular')
+      respond_to do |format|
+        format.json
+      end
+    end
   end
 
   # GET /mnoe/jpi/v1/marketplace/1
   def show
     @app = MnoEnterprise::App.find(params[:id])
+  end
+
+  def app_relation
+    if MnoEnterprise.marketplace_listing
+      MnoEnterprise::App.where('nid.in' => MnoEnterprise.marketplace_listing)
+    else
+      MnoEnterprise::App.all
+    end
   end
 end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
@@ -31,14 +31,20 @@ module MnoEnterprise
         'single_billing' => app.single_billing?,
         'tiny_description' => app.tiny_description,
         'description' => markdown(app.sanitized_description),
+        'known_limitations' => markdown(app.known_limitations),
+        'getting_started' => markdown(app.getting_started),
         'testimonials' => app.testimonials,
         'pictures' => app.pictures,
         'pricing_plans' => app.pricing_plans,
         'rank' => app.rank,
+        'support_url' => app.support_url,
+        'key_workflows'  => app.key_workflows,
+        'key_features' => app.key_features,
         'multi_instantiable' => app.multi_instantiable,
         'subcategories' => app.subcategories,
         'average_rating' => app.average_rating,
-        'running_instances_count' => app.running_instances_count
+        'running_instances_count' => app.running_instances_count,
+        'shared_entities' => []
       }
     end
 

--- a/core/app/models/mno_enterprise/app.rb
+++ b/core/app/models/mno_enterprise/app.rb
@@ -42,6 +42,7 @@ module MnoEnterprise
     has_many :reviews,   class_name: 'AppReview'
     has_many :feedbacks, class_name: 'AppFeedback'
     has_many :questions, class_name: 'AppQuestion'
+    has_many :shared_entities
 
     # Return the list of available categories
     def self.categories(list = nil)

--- a/core/app/models/mno_enterprise/shared_entity.rb
+++ b/core/app/models/mno_enterprise/shared_entity.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Endpoint:
+#  - /v1/app/:app_id/shared_entities
+#
+#  id                :integer         not null, primary key
+#  nid               :string
+#  name              :string
+#  created_at        :datetime        not null
+#  updated_at        :datetime        not null
+
+module MnoEnterprise
+  class SharedEntity < BaseResource
+    include MnoEnterprise::Concerns::Models::SharedEntity
+  end
+end

--- a/core/lib/mno_enterprise/concerns/models/shared_entity.rb
+++ b/core/lib/mno_enterprise/concerns/models/shared_entity.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Endpoint:
+#  - /v1/app/:app_id/shared_entities
+#
+#  id                :integer         not null, primary key
+#  nid               :string
+#  name              :string
+#  created_at        :datetime        not null
+#  updated_at        :datetime        not null
+
+module MnoEnterprise::Concerns::Models::SharedEntity
+  extend ActiveSupport::Concern
+
+  #==================================================================
+  # Included methods
+  #==================================================================
+  included do
+    # == Relationships ==============================================
+    belongs_to :app
+  end
+
+  #==================================================================
+  # Class methods
+  #==================================================================
+  module ClassMethods
+    # def some_class_method
+    #   'some text'
+    # end
+  end
+
+  #==================================================================
+  # Instance methods
+  #==================================================================
+end

--- a/core/lib/mno_enterprise/testing_support/factories/apps.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/apps.rb
@@ -16,11 +16,15 @@ FactoryGirl.define do
     tags ['Foo', 'Bar']
     key_benefits ['Super', 'Hyper', 'Good']
     key_features ['Super', 'Hyper', 'Good']
+    key_workflows ['1st workflow', '2nd workflow']
+    known_limitations "No limitations"
     testimonials [{text: 'Bla', company: 'Doe Pty Ltd', author: 'John'}]
     worldwide_usage 120000
     tiny_description "A great app"
     stack 'cube'
     terms_url "http://opensource.org/licenses/MIT"
+    support_url "http://example.com/su  pport"
+    getting_started "Let's get started"
     appinfo { {} }
     average_rating { rand(1..5) }
     sequence(:rank) { |n| n }
@@ -28,6 +32,8 @@ FactoryGirl.define do
     pricing_plans { {
       'default' => [{name: 'Monthly Plan', price: '20.0', currency: 'AUD', factor: '/month'}]
     } }
+
+    shared_entities []
 
     trait :cloud do
       stack 'cloud'

--- a/core/spec/models/mno_enterprise/shared_entity_spec.rb
+++ b/core/spec/models/mno_enterprise/shared_entity_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+require 'shoulda/matchers'
+
+module MnoEnterprise
+  RSpec.describe SharedEntity, type: :model do
+  end
+end


### PR DESCRIPTION
Marketplace now returns new fields and shared entities

As the `Marketplace#index` response is starting to get quite big (and the list of  apps from MnoHub as well), I've added a cache which add an extra request to MnoHub.
It adds ~50ms to the request but in most cases it avoids fetching the full App List from MnoHub (and `Her` deserialising it!).
Fetching  apps and rendering the json was quite fast, deserialising and instantiating the list of `MnoEnterprise::App` was taking the most time.

Contrary to the previous "dumb" cache (10min) this cache should always be fresh. It also allows the user browser to cache it.