### PR TITLE
[MNOE-27] Fix double loading

### DIFF
--- a/core/config/initializers/audit_log.rb
+++ b/core/config/initializers/audit_log.rb
@@ -1,5 +1,3 @@
-# Somehow the whole config/ folder is loaded twice
-# To investigate
 unless defined? AUDIT_LOG_CONFIG
   AUDIT_LOG_CONFIG = Rails.application.config_for('audit_log') rescue {}
 end

--- a/core/lib/devise_extension.rb
+++ b/core/lib/devise_extension.rb
@@ -27,10 +27,6 @@ end
 # modules
 Devise.add_module :password_expirable, controller: :password_expirable, model: 'devise/models/password_expirable', route: :password_expired
 
-module DeviseExtension
-  class Engine < ::Rails::Engine
-    ActiveSupport.on_load(:action_controller) do
-      include DeviseExtension::Controllers::Helpers
-    end
-  end
+ActiveSupport.on_load(:action_controller) do
+  include DeviseExtension::Controllers::Helpers
 end


### PR DESCRIPTION
Fix double loading of rake tasks and initializers

This was defining another Engine in `core` which was loading all the `core/config/initializers` a second time.