### PR TITLE
[APIv2] Fix JsonApiClient::OrmAdapter.find_first

### DIFF
--- a/core/lib/json_api_client_extension/json_api_client_orm_adapter.rb
+++ b/core/lib/json_api_client_extension/json_api_client_orm_adapter.rb
@@ -31,7 +31,7 @@ module JsonApiClient
 
     # @see OrmAdapter::Base#find_first
     def find_first(options = {})
-      klass.where(options).limit(1).first
+      find_all(options).first
     end
 
     # @see OrmAdapter::Base#find_all

--- a/core/spec/lib/json_api_client_extension/json_api_client_orm_adapter_spec.rb
+++ b/core/spec/lib/json_api_client_extension/json_api_client_orm_adapter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  RSpec.describe JsonApiClient::OrmAdapter do
+    pending "add specs for JsonApiClient::OrmAdapter: #{__FILE__}"
+
+    let(:dummy_class) do
+      Class.new(MnoEnterprise::BaseResource) do
+        def self.name
+          'DummyClass'
+        end
+      end
+    end
+    let(:adapter) { dummy_class.to_adapter }
+
+    describe '.find_first' do
+      # Fetch only one record
+      let!(:stub) { stub_api_v2(:get, '/dummy_classes', [], [], {filter: {name: 'Test'}, 'page[number]': 1, 'page[size]': 1}) }
+
+      before { adapter.find_first(name: 'Test') }
+      it { expect(stub).to have_been_requested }
+    end
+  end
+end

--- a/core/spec/models/mno_enterprise/base_resource_spec.rb
+++ b/core/spec/models/mno_enterprise/base_resource_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  RSpec.describe BaseResource, type: :model do
+
+    pending "add specs for MnoEnterprise::BaseResource: #{__FILE__}"
+
+  end
+end


### PR DESCRIPTION
Fix the `find_first` as `first` already manage the limit.

@x4d3 I've added some skeleton specs for `JsonApiClient::OrmAdapter` and `MnoEnterprise::BaseResource`, could add this the todo list?