### PR TITLE
[MNOE-510] Fix confirmation not being sent

### DIFF
--- a/core/app/models/mno_enterprise/base_resource.rb
+++ b/core/app/models/mno_enterprise/base_resource.rb
@@ -61,16 +61,16 @@ module MnoEnterprise
     # emulate active record call of callbacks
     def save(*args)
       run_callbacks :save do
-        super()
+        run_callbacks :update do
+          super()
+        end
       end
     end
 
     # emulate active record call of callbacks, a bit different as before_update is called before before_save
     def update_attributes(attrs = {})
       self.attributes = attrs
-      run_callbacks :update do
-        save
-      end
+      save
     end
 
     def cache_key(*timestamp_names)

--- a/core/app/models/mno_enterprise/base_resource.rb
+++ b/core/app/models/mno_enterprise/base_resource.rb
@@ -60,8 +60,9 @@ module MnoEnterprise
 
     # emulate active record call of callbacks
     def save(*args)
+      callback_kind = new_record? ? :create : :update
       run_callbacks :save do
-        run_callbacks :update do
+        run_callbacks callback_kind do
           super()
         end
       end

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -79,6 +79,27 @@ module MnoEnterprise
 
     end
 
+
+    # Fix issue that prevented email to be sent when signing up
+    # In devise there is a call to postpone_email_change_until_confirmation_and_regenerate_confirmation_token that reset
+    # the email to email_was which is nil when a user is being created the first time
+    # The call to postpone_email_change_until_confirmation_and_regenerate_confirmation_token depends on postpone_email_change
+    # in the current implementation, there is no apparent case for when tue email_was is nil.
+    # Found a workaround on https://github.com/plataformatec/devise/issues/1691
+    # Original Devise implementation
+    # def postpone_email_change?
+    #   postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && self.email.present?
+    #   @bypass_confirmation_postpone = false
+    #   postpone
+    # end
+    def postpone_email_change?
+      if self.email_was.nil?
+        @reconfirmation_required = true
+        return false
+      end
+      super
+    end
+
     def authenticatable_salt
       read_attribute(:authenticatable_salt)
     end


### PR DESCRIPTION
I am not entirely sure it is the best solution.

I am a bit confused by the original implementation from devise and I don't see the case where they manage when email_was is nil. 

Original Implementation
```
        def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
          @reconfirmation_required = true
          self.unconfirmed_email = self.email
          self.email = self.email_was
          self.confirmation_token = nil
          generate_confirmation_token
        end

        def postpone_email_change?
          postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && self.email.present?
          @bypass_confirmation_postpone = false
          postpone
        end
```
Without this change, at user creation, on `resource.save`, `postpone_email_change_until_confirmation_and_regenerate_confirmation_token` is called because `postpone_email_change?` is `true`, `resource.email` is set to `nil` and then validation are failing as the `email` is nil.

The error may be due to the workaround implemented for the callback around saving, emulating Active record behaviour. Maybe it's not in the right order.

@ouranos We could discuss it together.

