### PR TITLE
[MNOE-542] Parameterise ActionMailer config

### DIFF
--- a/core/lib/generators/mno_enterprise/install/templates/config/application.yml
+++ b/core/lib/generators/mno_enterprise/install/templates/config/application.yml
@@ -6,3 +6,8 @@ tenant_key: my_tenant_access_key
 
 # Rails secret key
 SECRET_KEY_BASE: <%= SecureRandom.hex(64) %>
+
+<% unless ENV['RAILS_ENV'] == "test" %>
+mailer_default_host: localhost:7000
+mailer_default_protocol: http
+<% end %>

--- a/core/lib/mno_enterprise/engine.rb
+++ b/core/lib/mno_enterprise/engine.rb
@@ -44,6 +44,18 @@ module MnoEnterprise
       ::Rails.configuration.cache_store = :memory_store, { size: 32.megabytes }
     end
 
+    # Configure the mailer default host
+    config.before_initialize do
+      if ENV['mailer_default_host'].present?
+        opts = {
+          host: ENV['mailer_default_host'],
+          protocol: ENV['mailer_default_protocol'].presence || 'https'
+        }
+        config.action_mailer.default_url_options = opts
+        config.action_mailer.asset_host = opts[:protocol] + '://' + opts[:host]
+      end
+    end
+
     # Enable ActionController caching
     config.before_initialize do
       Rails.application.config.action_controller.perform_caching = true

--- a/rails-template/mnoe-app-template.rb
+++ b/rails-template/mnoe-app-template.rb
@@ -50,11 +50,6 @@ def apply_template!
   # Create uat environment
   copy_file File.join(destination_root, 'config/environments/production.rb'), 'config/environments/uat.rb'
 
-  # Edit config/environments/*.rb
-  Dir["config/environments/*.rb"].each do |file|
-    insert_into_file file, "\n  config.action_mailer.default_url_options = {host: 'localhost:7000', protocol: 'http'}\n", before: /^end$/
-  end
-
   # secrets
   append_to_file 'config/secrets.yml' do
     'uat:


### PR DESCRIPTION
@alachaum what do you think?

I didn't use `NEX_xxx` variables here as I want this part to be platform agnostic. I can set `mailer_default_host` on the Docker entrypoint based on the `NEX_xxx` variables.

Come to think of it, `mailer_default_host|protocol` is not the most accurate name as it's used to generate link (to page and assets) in the emails we send. It's actually referring to the frontend host.

Not sure how to spec that as I can't reinitialise the app in rspec.

(WIP) I'm doing another pass on all the config to make sure nothing is missing