### PR TITLE
[IMPAC-623] create email alert on widget kpi create

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -61,6 +61,8 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
       # Creates a default alert for kpis created with targets defined.
       if kpi.targets.present?
         current_user.alerts.create({service: 'inapp', impac_kpi_id: kpi.id})
+        # TODO: should widget KPIs create an email alert automatically?
+        current_user.alerts.create({service: 'email', impac_kpi_id: kpi.id}) if widget.present?
         # TODO: reload is adding the recipients to the kpi alerts (making another request).
         kpi.reload
       end


### PR DESCRIPTION
@ouranos small change to automatically create email alerts for widget KPIs on create - please review, let me know if this change can be specced? As I'm not sure it's possible with api stub jazz.

