### PR TITLE
[MNOE-570] Storing the time of agreement to TOS

### DIFF
--- a/api/app/views/mno_enterprise/auth/confirmations/_form.html.haml
+++ b/api/app/views/mno_enterprise/auth/confirmations/_form.html.haml
@@ -1,4 +1,4 @@
-%div{ 'ng-init' => "user = { $pwdScore: {}, name: '#{resource.name}', surname: '#{resource.surname}', phone: '#{resource.phone}' }" }
+%div{ 'ng-init' => "user = { $pwdScore: {}, name: '#{resource.name}', surname: '#{resource.surname}', phone: '#{resource.phone}'}" }
 
 = form_for(resource, as: resource_name, :url => mno_enterprise.user_confirmation_finalize_path, :html => { 'name' => 'loginForm', :class => 'autofill-detect text-center' }) do |f|
 
@@ -38,6 +38,15 @@
         %small.text-danger= t('activemodel.errors.mno_enterprise/user.password_weak')
 
   = f.hidden_field :confirmation_token, value: @confirmation_token
+
+  - unless @user[:meta_data][:tos_accepted_at]
+    %br
+    .row
+      .col-sm-12
+        .checkbox-section.text-center
+          = check_box_tag 'tos', 'accept', false, required: true, style: "margin-top: -3px;", 'ng-model' => 'acceptTos'
+          %label{for: 'tos'}= t('mno_enterprise.auth.registrations.new.user_accept')
+          = link_to t('mno_enterprise.auth.registrations.new.tos'), MnoEnterprise.router.terms_url, target: '_blank'
 
   %br/
   %div

--- a/core/lib/mno_enterprise/concerns/controllers/auth/confirmations_controller.rb
+++ b/core/lib/mno_enterprise/concerns/controllers/auth/confirmations_controller.rb
@@ -92,6 +92,9 @@ module MnoEnterprise::Concerns::Controllers::Auth::ConfirmationsController
     end
 
     if resource.errors.empty?
+      if params[:tos]
+        params[:user][:meta_data] = resource.meta_data.merge(tos_accepted_at: Time.current)
+      end
       resource.assign_attributes(params[:user]) unless resource.confirmed?
       resource.perform_confirmation(@confirmation_token)
       resource.save

--- a/core/lib/mno_enterprise/concerns/controllers/auth/confirmations_controller.rb
+++ b/core/lib/mno_enterprise/concerns/controllers/auth/confirmations_controller.rb
@@ -92,7 +92,7 @@ module MnoEnterprise::Concerns::Controllers::Auth::ConfirmationsController
     end
 
     if resource.errors.empty?
-      if params[:tos]
+      if params[:tos] == "accept"
         params[:user][:meta_data] = resource.meta_data.merge(tos_accepted_at: Time.current)
       end
       resource.assign_attributes(params[:user]) unless resource.confirmed?

--- a/core/lib/mno_enterprise/concerns/controllers/auth/registrations_controller.rb
+++ b/core/lib/mno_enterprise/concerns/controllers/auth/registrations_controller.rb
@@ -20,7 +20,8 @@ module MnoEnterprise::Concerns::Controllers::Auth::RegistrationsController
           :surname,
           :company,
           :phone,
-          :phone_country_code
+          :phone_country_code,
+          {meta_data: [:tos_accepted_at]}
         )}
       end
   end
@@ -44,6 +45,11 @@ module MnoEnterprise::Concerns::Controllers::Auth::RegistrationsController
 
   # POST /resource
   def create
+    #  Filling the time at which TOS were accepted
+    if params[:tos]
+      params[:user][:meta_data] = {tos_accepted_at: Time.current}
+    end
+
     build_resource(sign_up_params)
     resource.password ||= Devise.friendly_token
 

--- a/core/lib/mno_enterprise/testing_support/factories/users.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/users.rb
@@ -21,6 +21,7 @@ FactoryGirl.define do
     updated_at 2.days.ago
     sso_session "1fdd5sf5a73D7sd1as2a4sd541"
     admin_role nil
+    meta_data Hash[]
 
     confirmation_sent_at 2.days.ago
     confirmation_token "wky763pGjtzWR7dP44PD"

--- a/frontend/spec/controllers/mno_enterprise/auth/confirmations_controller_spec.rb
+++ b/frontend/spec/controllers/mno_enterprise/auth/confirmations_controller_spec.rb
@@ -2,28 +2,28 @@ require 'rails_helper'
 
 module MnoEnterprise
   module Auth
-    
+
     describe ConfirmationsController, type: :controller do
       render_views
       routes { MnoEnterprise::Engine.routes }
       before { request.env["devise.mapping"] = Devise.mappings[:user] } #bypass devise router
-      
-      
+
+
       let(:user) { build(:user) }
       let(:new_email) { user.email + '.au' }
       let(:email_params) {{ filter: { email: user.email }, limit: 1 }}
       let(:new_email_params) {{ filter: { email: new_email }, limit: 1 }}
-      
+
       before { allow(MnoEnterprise::User).to receive(:find_for_confirmation).with(any_args).and_return(user) }
-      
+
       before { api_stub_for(get: "/users", params: email_params, respond_with: []) }
       before { api_stub_for(get: "/users", respond_with: [user]) }
       before { api_stub_for(get: "/org_invites", respond_with: []) }
       before { api_stub_for(get: "/users/#{user.id}/organizations", respond_with: []) }
 
       before { api_stub_for(put: "/users/#{user.id}", respond_with: user) }
-      
-    
+
+
       describe 'GET #show' do
         subject { get :show, confirmation_token: user.confirmation_token }
 
@@ -34,9 +34,9 @@ module MnoEnterprise
           it { expect(user.email).to eq(new_email) }
           it { expect(response).to redirect_to(root_path) }
         end
-      
+
         describe 'unconfirmed user' do
-        
+
           let(:tos_accepted_at) { nil }
           before { user.meta_data[:tos_accepted_at] = tos_accepted_at }
 
@@ -51,7 +51,7 @@ module MnoEnterprise
               expect(response.body).not_to include('id="tos"')
             end
           end
-          
+
           context 'when TOS not accepted' do
             it 'shows the TOS checkbox' do
               expect(response.body).to include('id="tos"')
@@ -59,20 +59,20 @@ module MnoEnterprise
           end
         end
       end
-      
+
       describe 'PATCH #finalize' do
         let(:previous_url) { nil }
         let(:user_params) {{ name: 'Robert', surname: 'Jack', password: 'somepassword', confirmation_token: user.confirmation_token }}
         subject { patch :finalize, user: user_params }
-        
+
         before { session[:previous_url] = previous_url }
-        
+
         describe 'confirmed user' do
           before { subject }
           it { expect(user.name).to_not eq(user_params[:name]) }
           it { expect(response).to redirect_to(root_path) }
         end
-        
+
         describe 'unconfirmed user' do
           before { user.confirmed_at = nil }
           before { subject }
@@ -80,13 +80,13 @@ module MnoEnterprise
           it { expect(user.surname).to eq(user_params[:surname]) }
           it { expect(user.password).to eq(user_params[:password]) }
           it { expect(response).to redirect_to(MnoEnterprise.router.dashboard_path) }
-          
+
           describe 'with previous url' do
             let(:previous_url) { "/some/redirection" }
             it { expect(response).to redirect_to(previous_url) }
           end
         end
-        
+
         describe 'invalid confirmation token ' do
           let(:user_with_errors) { obj = MnoEnterprise::User.new; obj.errors[:base] << "Invalid confirmation token"; obj }
           before { allow(MnoEnterprise::User).to receive(:find_for_confirmation).with(any_args).and_return(user_with_errors) }
@@ -96,6 +96,6 @@ module MnoEnterprise
         end
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
The time of agreement of TOS is stored in user[:metadata][tos_accepted_at]
It is then used in the /confirmation to create (or not) the TOS checkbox.
@ouranos 