### PR TITLE
[MNOE-588] TenantConfig - Allow empty arrays

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
@@ -1,5 +1,6 @@
 module MnoEnterprise
   class Jpi::V1::Admin::TenantsController < Jpi::V1::Admin::BaseResourceController
+    before_action :fix_json_params, only: :update
 
     # GET /mnoe/jpi/v1/admin/tenant
     def show
@@ -70,6 +71,28 @@ module MnoEnterprise
 
     def tenant_cert_params
       params.require(:tenant).permit(:domain, :certificate, :private_key, :ca_bundle)
+    end
+
+    # Bypass Rails `deep_munge` which replace empty arrays by nil:
+    #   Value for params[:...][:available_locales] was set to nil, because it was one of [], [null] or [null, null, ...].
+    #
+    # See http://guides.rubyonrails.org/v4.2/security.html#unsafe-query-generation for more information.
+    #
+    # We can remove this once migrating to Rails 5 as the behavior has changed in Rails 5:
+    # +------------------+--------------------+-------------------+
+    # | JSON             | Params (Rails 4.2) | Params (Rails 5)  |
+    # +------------------+--------------------+-------------------+
+    # | { "person": [] } | { :person => nil } | { :person => [] } |
+    # +------------------+--------------------+-------------------+
+    def fix_json_params
+      if request.format.json?
+        body = request.body.read
+        request.body.rewind
+        unless body == ''
+          unmunged_body = ActiveSupport::JSON.decode(body)
+          params.merge!(unmunged_body)
+        end
+      end
     end
   end
 end

--- a/api/spec/requests/mnoe/jpi/v1/admin/tenants_spec.rb
+++ b/api/spec/requests/mnoe/jpi/v1/admin/tenants_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  RSpec.describe 'Admin::Tenant API', type: :request do
+    include DeviseRequestSpecHelper
+    include RSpec::Rails::ViewRendering
+    render_views
+
+    before { stub_audit_events }
+
+    let(:tenant) { build(:tenant,  domain: 'tenant.domain.test')}
+    let(:user) { build(:user, :admin, mnoe_tenant: tenant) }
+
+    before do
+      sign_in(user)
+
+      stub_api_v2(:get, '/tenant', tenant)
+      stub_api_v2(:patch, '/tenant', tenant)
+    end
+
+    # We need to use a request spec to trigger Rails `deep_munge`
+    describe 'PATCH /mnoe/jpi/v1/admin/tenant' do
+      let(:tenant_params) { {frontend_config: {}} }
+      let(:data) { {tenant: tenant_params} }
+
+      subject { patch '/mnoe/jpi/v1/admin/tenant', data.to_json }
+
+      it 'is successful' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      describe 'deep_munge' do
+        let(:tenant_params) { {frontend_config: {foo: {bar: []}}} }
+
+        it 'does not munge the frontend config' do
+          allow(MnoEnterprise::Tenant).to receive(:show).and_return(tenant)
+          expect(tenant).to receive(:update_attributes).with(tenant_params)
+          subject
+        end
+      end
+    end
+  end
+end

--- a/core/lib/mno_enterprise/testing_support/devise_request_spec_helper.rb
+++ b/core/lib/mno_enterprise/testing_support/devise_request_spec_helper.rb
@@ -1,0 +1,24 @@
+module DeviseRequestSpecHelper
+
+  include Warden::Test::Helpers
+
+  def self.included(base)
+    base.before(:each) { Warden.test_mode! }
+    base.after(:each) { Warden.test_reset! }
+  end
+
+  def sign_in(resource)
+    login_as(resource, scope: warden_scope(resource))
+  end
+
+  def sign_out(resource)
+    logout(warden_scope(resource))
+  end
+
+  private
+
+  def warden_scope(resource)
+    Devise::Mapping.find_scope!(resource)
+  end
+
+end


### PR DESCRIPTION
Bypass Rails `deep_munge` on the Tenant config update to allow empty
array to be saved.