### PR TITLE
Fix Subscription#custom_data type

### DIFF
--- a/core/app/models/mno_enterprise/subscription.rb
+++ b/core/app/models/mno_enterprise/subscription.rb
@@ -10,7 +10,7 @@ module MnoEnterprise
     property :max_licenses, type: :integer
     property :available_licenses, type: :integer
     property :external_id, type: :string
-    property :custom_data, type: :string
+    property :custom_data
 
     has_one :product_instance
     has_one :organization


### PR DESCRIPTION
The field `Subscription#custom_data` is currently casted as a string which ends up as a "stringified hash" on the API side.

This PR ensures that `custom_data` is not casted to a specific type, therefore allowing hashes.