### PR TITLE
Retrieve organization specific pricing

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
@@ -13,14 +13,22 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
   #==================================================================
   # Instance methods
   #==================================================================
-  # GET /mnoe/jpi/v1/marketplace
+  # GET /mnoe/jpi/v1/marketplace(?organization_id=123)
+  # If an organization_id is passed then all pricing details will take
+  # into any markup/discounts applied specifically to this organization
   def index
     expires_in 0, public: true, must_revalidate: true
-    @last_modified = app_relation.order(updated_at: :desc).select(:updated_at).first&.updated_at
 
+    # Memoize parent_organization_id if any
+    org_id = parent_organization_id
+
+    # Compute cache key timestamp
+    @last_modified = app_relation(org_id).order(updated_at: :desc).select(:updated_at).first&.updated_at
+
+    # Fetch application listings & pricings
     if stale?(last_modified: @last_modified)
-      @apps = Rails.cache.fetch("marketplace/index-apps-#{@last_modified}-#{I18n.locale}") do
-        apps = MnoEnterprise::App.fetch_all(app_relation)
+      @apps = Rails.cache.fetch("marketplace/index-apps-#{@last_modified}-#{I18n.locale}-#{org_id}") do
+        apps = MnoEnterprise::App.fetch_all(app_relation(org_id).where)
         apps.sort_by! { |app| [app.rank ? 0 : 1, app.rank] } # the nil ranks will appear at the end
         apps
       end
@@ -33,12 +41,29 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
     end
   end
 
-  # GET /mnoe/jpi/v1/marketplace/1
+  # GET /mnoe/jpi/v1/marketplace/1(?organization_id=123)
   def show
-    @app = MnoEnterprise::App.includes(:app_shared_entities, {app_shared_entities: :shared_entity}).find_one(params[:id])
+    @app = app_relation(parent_organization_id).find_one(params[:id])
   end
 
-  def app_relation
-    MnoEnterprise::App.includes(:app_shared_entities, {app_shared_entities: :shared_entity}).where
+  #==================================================================
+  # Private
+  #==================================================================
+  private
+  # Return the default relation to use for index and show queries
+  def app_relation(org_id = nil)
+    rel = MnoEnterprise::App.includes(:app_shared_entities, { app_shared_entities: :shared_entity })
+    rel = rel.with_params(_metadata: { organization_id: org_id }) if org_id.present?
+    rel
+  end
+
+  # Return the organization_id passed as query parameters if the current_user
+  # has access to it
+  def parent_organization_id
+    return nil unless current_user && params[:organization_id].presence
+
+    MnoEnterprise::Organization
+      .select(:id)
+      .where('id' => params[:organization_id], 'users.id' => current_user.id).first&.id
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
@@ -9,6 +9,12 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::ProductsController
 
   def index
     query = MnoEnterprise::Product.apply_query_params(params).includes(DEPENDENCIES).where(active: true)
+
+    # Ensure prices include organization-specific markups/discounts
+    if params[:organization_id] && parent_organization
+      query = query.with_params(_metadata: { organization_id: parent_organization.id })
+    end
+
     @products = query.to_a
     response.headers['X-Total-Count'] = query.meta.record_count
   end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
@@ -117,6 +117,24 @@ module MnoEnterprise
         end
       end
 
+      # TODO: un-comment and test after global skip has been removed
+      # context 'with organization_id' do
+      #   subject { get :index, organization_id: organization.id }
+      #
+      #   let!(:user) { build(:user) }
+      #   let!(:current_user_stub) { stub_api_v2(:get, "/users/#{user.id}", user, %i(deletion_requests organizations orga_relations dashboards)) }
+      #
+      #   before { sign_in user }
+      #   before { stub_api_v2(:get, "/organizations", [organization], [], { fields: 'id', filter: { 'users.id' => user.id }}) }
+      #   before { stub_api_v2(:get, '/apps', [app], [], { _metadata: { organization_id: organization.id } }) }
+      #   before do
+      #     stub_api_v2(:get, '/apps', [app], [],
+      #       { _metadata: { organization_id: organization.id }, fields: { apps: 'updated_at' }, page:{ number: 1, size: 1 }, sort: '-updated_at'})
+      #   end
+      #
+      #   it { is_expected.to be_success }
+      # end
+
       describe 'caching' do
         context 'on the first request' do
           it { is_expected.to have_http_status(:ok) }


### PR DESCRIPTION
The objective of this PR is to proxy the organization_id to the remote API to retrieve organization specific pricing information for apps and products.

The organization_id is passed to the remote backend using the `_metadata` query parameter - which impacts the view/representation of the resources.