### PR TITLE
Core - Fix time parsing when timezone expanded

### DIFF
--- a/core/lib/json_api_client_extension/custom_parser.rb
+++ b/core/lib/json_api_client_extension/custom_parser.rb
@@ -21,7 +21,7 @@ module JsonApiClientExtension
           end
         when String
           if res =~ /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/i
-            return Time.iso8601(res)
+            return Time.parse(res)
           end
       end
       res

--- a/core/spec/models/mno_enterprise/base_resource_spec.rb
+++ b/core/spec/models/mno_enterprise/base_resource_spec.rb
@@ -5,6 +5,32 @@ module MnoEnterprise
 
     pending "add specs for MnoEnterprise::BaseResource: #{__FILE__}"
 
+    describe JsonApiClientExtension::CustomParser do
+      describe 'time parsing' do
+        subject { BaseResource.find(1).first }
+
+        let(:time_value) { '2017-09-06T00:16:22Z' }
+        let(:resp) { { data: { id: 1, type: 'base_resources', attributes: { some_date: time_value } } } }
+
+        before do
+          stub_request(:get, "#{MnoEnterprise::BaseResource.site}/base_resources/1?_locale=en").
+            to_return(status: 200, body: resp.to_json, headers: { content_type: 'application/vnd.api+json' })
+        end
+
+        describe 'with iso8601 date' do
+          it { expect { subject }.not_to raise_error }
+          it { expect(subject.some_date).to be_a(Time) }
+        end
+
+        describe 'with timezone expanded' do
+          let(:time_value) { '2017-09-06T00:16:22+0000' }
+
+          it { expect { subject }.not_to raise_error }
+          it { expect(subject.some_date).to be_a(Time) }
+        end
+      end
+    end
+
     describe LocaleMiddleware do
       before do
         I18n.available_locales = [:'en-AU', :en]


### PR DESCRIPTION
The current parser will fail if iso8601 dates have their timezone expanded. 

E.g. 
'2017-09-06T00:16:22+0000' instead of '2017-09-06T00:16:22Z'

This PR changes date parsing to use `Time.parse` instead of the stricter `Time.iso8601`