### PR TITLE
Add account manager scoping on subscriptions

### DIFF
--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/subscriptions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/subscriptions_controller_spec.rb
@@ -46,11 +46,16 @@ module MnoEnterprise
 
       let(:data) { JSON.parse(response.body) }
       let(:includes) { [:product_instance, :'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'] }
-      let(:expected_params) { { filter: { organization_id: organization.id }, _metadata: { act_as_manager: user.id } } }
+      let(:expected_params) do
+        {
+          filter: { id: subscription.id, organization_id: organization.id },
+          _metadata: { act_as_manager: user.id },
+          page: { number: 1, size: 1 } }
+      end
 
       before { allow(subscription).to receive(:license_assignments).and_return([]) }
       before { allow(subscription).to receive(:organization).and_return(organization) }
-      before { stub_api_v2(:get, "/subscriptions/#{subscription.id}", subscription, includes, expected_params) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, includes, expected_params) }
       before { subject }
 
       it { expect(data['subscription']['id']).to eq(subscription.id) }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/subscriptions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/subscriptions_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  describe Jpi::V1::Admin::SubscriptionsController, type: :controller do
+    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
+
+    render_views
+    routes { MnoEnterprise::Engine.routes }
+    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+
+    before(:each) do
+      Settings.merge!(dashboard: { marketplace: {provisioning: true } })
+      Rails.application.reload_routes!
+    end
+
+    #===============================================
+    # Assignments
+    #===============================================
+    let(:user) { build(:user, :admin) }
+    let!(:current_user_stub) { stub_api_v2(:get, "/users/#{user.id}", user, %i(deletion_requests organizations orga_relations dashboards)) }
+
+    let(:organization) { build(:organization) }
+    let(:subscription) { build(:subscription) }
+
+    #===============================================
+    # Specs
+    #===============================================
+    before { sign_in user }
+
+    describe 'GET #index' do
+      subject { get :index }
+
+      let(:data) { JSON.parse(response.body) }
+      let(:includes) { [:product_instance, :'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'] }
+      let(:expected_params) { { _metadata: { act_as_manager: user.id } } }
+
+      before { allow(subscription).to receive(:license_assignments).and_return([]) }
+      before { stub_api_v2(:get, "/subscriptions", [subscription], includes, expected_params) }
+      before { subject }
+
+      it { expect(data['subscriptions'].first['id']).to eq(subscription.id) }
+    end
+
+    describe 'GET #show' do
+      subject { get :show, id: subscription.id, organization_id: organization.id }
+
+      let(:data) { JSON.parse(response.body) }
+      let(:includes) { [:product_instance, :'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'] }
+      let(:expected_params) { { filter: { organization_id: organization.id }, _metadata: { act_as_manager: user.id } } }
+
+      before { allow(subscription).to receive(:license_assignments).and_return([]) }
+      before { allow(subscription).to receive(:organization).and_return(organization) }
+      before { stub_api_v2(:get, "/subscriptions/#{subscription.id}", subscription, includes, expected_params) }
+      before { subject }
+
+      it { expect(data['subscription']['id']).to eq(subscription.id) }
+    end
+  end
+end

--- a/core/app/models/mno_enterprise/subscription.rb
+++ b/core/app/models/mno_enterprise/subscription.rb
@@ -3,6 +3,9 @@ module MnoEnterprise
     property :created_at, type: :time
     property :updated_at, type: :time
 
+    property :billed_locally, type: :boolean
+    property :externally_provisioned, type: :boolean
+    property :local_product, type: :boolean
     property :status, type: :string
     property :subscription_type, type: :string
     property :start_date, type: :date


### PR DESCRIPTION
Scope GET calls to account manager id (current user) and verify permissions before performing controller actions.