### PR TITLE
Hide subtenant from the config screen

### DIFF
--- a/core/config/initializers/00_tenant_config_schema.rb
+++ b/core/config/initializers/00_tenant_config_schema.rb
@@ -466,6 +466,11 @@ MnoEnterprise::CONFIG_JSON_SCHEMA = {
         },
         sub_tenant: {
           type: "object",
+          # Disable sub_tenant activation for now
+          'x-schema-form': {
+            type: 'hidden',
+            notitle: true
+          },
           properties: {
             enabled: {
               type: "boolean",


### PR DESCRIPTION
Disabled until we figure a better to migrate roles when switching the
feature flag.
The feature can still be activated by toggling the flag manually.