### PR TITLE
[MNOE-659] Theme Previewer - Speedup Compilation

### DIFF
--- a/core/lib/generators/mno_enterprise/install/templates/stylesheets/variables.less
+++ b/core/lib/generators/mno_enterprise/install/templates/stylesheets/variables.less
@@ -112,7 +112,7 @@
 // Loaders
 //--------------------------------------
 @dashboard-loader-color:                        @text-strong-color;
-@dashboard-loader-icon:                         { .icon-fa(refresh); .fa-2x; .fa-spin; }; //pass a ruleset
+@dashboard-loader-icon:                         { .icon-fa(refresh); .fa-2x; .fa-spin; };
 
 /*-----------------------------------------------------------------------*/
 /*                        Dashboard > Apps Section                       */

--- a/frontend/app/assets/stylesheets/mno_enterprise/variables.less
+++ b/frontend/app/assets/stylesheets/mno_enterprise/variables.less
@@ -112,7 +112,7 @@
 // Loaders
 //--------------------------------------
 @dashboard-loader-color:                        @text-strong-color;
-@dashboard-loader-icon:                         { .icon-fa(refresh); .fa-2x; .fa-spin; }; //pass a ruleset
+@dashboard-loader-icon:                         { .icon-fa(refresh); .fa-2x; .fa-spin; };
 
 /*-----------------------------------------------------------------------*/
 /*                        Dashboard > Apps Section                       */

--- a/frontend/lib/tasks/mnoe_frontend_tasks.rake
+++ b/frontend/lib/tasks/mnoe_frontend_tasks.rake
@@ -90,7 +90,7 @@ namespace :mnoe do
     # Build the previewer less stylesheet
     # Return the relative path of the compiled less stylesheet
     def build_theme_previewer_src_less(frontend_tmp_folder)
-      # This file containers the bower (wiredep) and injector tags (see less_injector)
+      # This file contains the bower (wiredep) and injector tags (see less_injector)
       src_file = "src/app/index.less"
 
       # The destination file is built under src so as to obtain relative
@@ -101,12 +101,17 @@ namespace :mnoe do
 
       Dir.chdir(frontend_tmp_folder) do
         cp src_file, dst_file
+
+        # Wiredep replaces the bower:less tag in the file
+        # by less @imports to the actual dependencies (e.g. bootstrap)
         sh "#{WIREDEP_CMD} --src #{dst_file}"
 
         # Do not inject these files as they are either
         # used as template or are the destination file
         excluded = [src_file, dst_file]
 
+        # List of files to be concatenated and injected in
+        # the final less file. Order matters.
         included = [
           'src/app/stylesheets/theme.less',
           'src/app/stylesheets/variables-default.less',
@@ -119,6 +124,8 @@ namespace :mnoe do
           'src/images/**/*.less'
         ]
 
+        # The 'injector' tag in the file gets replaced by the
+        # content of the files above
         less_injector(dst_file, included, excluded)
       end
 

--- a/frontend/lib/tasks/mnoe_frontend_tasks.rake
+++ b/frontend/lib/tasks/mnoe_frontend_tasks.rake
@@ -127,6 +127,10 @@ namespace :mnoe do
         # The 'injector' tag in the file gets replaced by the
         # content of the files above
         less_injector(dst_file, included, excluded)
+
+        # Adjust path to bower_components
+        content = File.read(dst_file).gsub('../../bower_components', '../bower_components')
+        File.write(dst_file, content)
       end
 
       return dst_file


### PR DESCRIPTION
Bypass gulp and build less files manually to speedup the overall theme previewer compilation.

Need to be merged after https://github.com/maestrano/mno-enterprise-angular/pull/350