### PR TITLE
[MNOE-665] Handle RO feature flags

### DIFF
--- a/core/app/models/mno_enterprise/tenant_config.rb
+++ b/core/app/models/mno_enterprise/tenant_config.rb
@@ -45,8 +45,8 @@ module MnoEnterprise
       # Reconfigure mnoe
       reconfigure_mnoe!
 
-      # TODO: update JSON_SCHEMA with readonly fields
-      refresh_json_schema!
+      # Update JSON_SCHEMA with readonly flags (`<field>_readonly`)
+      refresh_json_schema!(frontend_config)
 
       # # Save settings in YAML format for easy debugging
       # Rails.logger.debug "Settings loaded -> Saving..."
@@ -81,18 +81,10 @@ module MnoEnterprise
 
     # Update the JSON schema with values available after initialization
     # TODO: Refactor to use Proc in the JSON Schema and call them
-    def self.refresh_json_schema!
-      # Re-evaluate the availables locales as the list is only populated after initialization
-      available_locales = I18n.available_locales.map(&:to_s).select {|x| x =~ /[[:alpha:]]{2}-[A-Z]{2}/}
-      locale_map = Hash[available_locales.map {|l| [l, I18n.t('language', locale: l, fallback: false, default: nil) || l] }]
-
-      i18n_properties = json_schema['properties']['system']['properties']['i18n']['properties']
-      i18n_properties['available_locales']['items']['enum'] = available_locales
-      i18n_properties['preferred_locale']['enum'] = available_locales
-      i18n_properties['available_locales']['x-schema-form']['titleMap'] = locale_map
-      i18n_properties['preferred_locale']['x-schema-form']['titleMap'] = locale_map
-
+    def self.refresh_json_schema!(frontend_config)
+      update_locales_list!
       update_application_list!
+      update_readonly_fields(json_schema, frontend_config)
     end
 
     # Fetch the Tenant#frontend_config from MnoHub
@@ -121,6 +113,39 @@ module MnoEnterprise
       end
     end
 
+    # Flag field as readonly in the config schema
+    # A field is readonly if the `<field>_readonly` key is `true` in the `frontend_config`
+    def self.update_readonly_fields(schema, frontend_config)
+      frontend_config.each do |current_key, value|
+        if current_key =~ /_readonly$/
+          # Flag field as RO
+          schema['properties'][current_key.gsub('_readonly', '')].merge!('readonly' => true)
+        elsif value.is_a?(Hash)
+          if (inner_schema = schema['properties'][current_key])
+            update_readonly_fields(inner_schema, value)
+          else
+            warn "Warn: Ignoring config for #{current_key}"
+          end
+        end
+      end
+      schema
+    end
+
+    # Re-evaluate the availables locales as the list is only populated after initialization
+    # TODO: replace with a Proc.call
+    def self.update_locales_list!
+      available_locales = I18n.available_locales.map(&:to_s).select {|x| x =~ /[[:alpha:]]{2}-[A-Z]{2}/}
+      locale_map = Hash[available_locales.map {|l| [l, I18n.t('language', locale: l, fallback: false, default: nil) || l]}]
+
+      i18n_properties = json_schema['properties']['system']['properties']['i18n']['properties']
+      i18n_properties['available_locales']['items']['enum'] = available_locales
+      i18n_properties['preferred_locale']['enum'] = available_locales
+      i18n_properties['available_locales']['x-schema-form']['titleMap'] = locale_map
+      i18n_properties['preferred_locale']['x-schema-form']['titleMap'] = locale_map
+    end
+
+    # Populate the app list after fetching it from MnoHub
+    # TODO: replace with a Proc.call
     def self.update_application_list!
       available_app_nids = App.all.map(&:nid)
       available_app_map = Hash[App.all.map{|a| [a.nid, a.name]}]

--- a/core/app/models/mno_enterprise/tenant_config.rb
+++ b/core/app/models/mno_enterprise/tenant_config.rb
@@ -80,11 +80,10 @@ module MnoEnterprise
     end
 
     # Update the JSON schema with values available after initialization
-    # TODO: Refactor to use Proc in the JSON Schema and call them
     def self.refresh_json_schema!(frontend_config)
       update_locales_list!
       update_application_list!
-      update_readonly_fields(json_schema, frontend_config)
+      flag_readonly_fields(json_schema, frontend_config)
     end
 
     # Fetch the Tenant#frontend_config from MnoHub
@@ -115,14 +114,14 @@ module MnoEnterprise
 
     # Flag field as readonly in the config schema
     # A field is readonly if the `<field>_readonly` key is `true` in the `frontend_config`
-    def self.update_readonly_fields(schema, frontend_config)
+    def self.flag_readonly_fields(schema, frontend_config)
       frontend_config.each do |current_key, value|
-        if current_key =~ /_readonly$/
+        if field_label = current_key[/(.*)_readonly$/, 1]
           # Flag field as RO
-          schema['properties'][current_key.gsub('_readonly', '')].merge!('readonly' => true)
+          schema['properties'][field_label]['readonly'] = true
         elsif value.is_a?(Hash)
           if (inner_schema = schema['properties'][current_key])
-            update_readonly_fields(inner_schema, value)
+            flag_readonly_fields(inner_schema, value)
           else
             warn "Warn: Ignoring config for #{current_key}"
           end

--- a/core/spec/models/mno_enterprise/tenant_config_spec.rb
+++ b/core/spec/models/mno_enterprise/tenant_config_spec.rb
@@ -72,7 +72,7 @@ describe MnoEnterprise::TenantConfig do
 
   describe '.refresh_json_schema!' do
     before { stub_api_v2(:get, '/apps', [build(:app, name: 'My App', nid: 'my-app')]) }
-    subject { described_class.refresh_json_schema! }
+    subject { described_class.refresh_json_schema!({}) }
 
     let(:preferred_locale_hash) do
       {
@@ -182,5 +182,79 @@ describe MnoEnterprise::TenantConfig do
       let(:output) { {'foo' => 'Hello World', 'bar' => {'enabled' => true} } }
       it { is_expected.to eq(output)}
     end
+  end
+
+  describe '.update_readonly_fields' do
+    subject { described_class.update_readonly_fields(schema.with_indifferent_access, config) }
+
+    let(:schema) {
+      {
+        type: "object",
+        properties: {
+          admin_panel: {
+            type: "object",
+            properties: {
+              audit_log: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                    default: true
+                  }
+                }
+              },
+              impersonation: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                    default: true
+                  }
+                }
+              }
+            }
+
+          }
+        }
+      }
+    }
+
+    let(:config) {
+      {'admin_panel' => {'audit_log' => {'enabled' => true, 'enabled_readonly' => true}} }
+    }
+
+    let(:output) {
+      {
+        type: "object",
+        properties: {
+          admin_panel: {
+            type: "object",
+            properties: {
+              audit_log: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                    default: true,
+                    readonly: true
+                  }
+                }
+              },
+              impersonation: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                    default: true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    it { is_expected.to eq(output.with_indifferent_access) }
   end
 end

--- a/core/spec/models/mno_enterprise/tenant_config_spec.rb
+++ b/core/spec/models/mno_enterprise/tenant_config_spec.rb
@@ -184,8 +184,8 @@ describe MnoEnterprise::TenantConfig do
     end
   end
 
-  describe '.update_readonly_fields' do
-    subject { described_class.update_readonly_fields(schema.with_indifferent_access, config) }
+  describe '.flag_readonly_fields' do
+    subject { described_class.flag_readonly_fields(schema.with_indifferent_access, config) }
 
     let(:schema) {
       {


### PR DESCRIPTION
Feature flags can be marked as ReadOnly on the MnoHub side.
If a the config contains `flag_readonly: true`, the flag is considered
as readonly and marked as such in the schema.