### PR TITLE
[MNOE-689] API V2 - SubTenant replace mass assignment of relation ship by diff

### DIFF
--- a/api/app/controllers/mno_enterprise/impersonate_controller.rb
+++ b/api/app/controllers/mno_enterprise/impersonate_controller.rb
@@ -9,7 +9,7 @@ module MnoEnterprise
     # GET /impersonate/user/123
     def create
       session[:impersonator_redirect_path] = params[:redirect_path].presence
-      @user = MnoEnterprise::User.find_one(params[:user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams, :user_access_requests)
+      @user = MnoEnterprise::User.find_one(params[:user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams, :user_access_requests, :sub_tenant)
       unless @user.present?
         return redirect_with_error('User does not exist')
       end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller.rb
@@ -13,9 +13,7 @@ module MnoEnterprise
 
     # GET /mnoe/jpi/v1/admin/sub_tenants/1
     def show
-      @sub_tenant = MnoEnterprise::SubTenant.find_one(params[:id], :clients, :account_managers)
-      @sub_tenant_clients = @sub_tenant.clients
-      @sub_tenant_account_managers = @sub_tenant.account_managers
+      @sub_tenant = MnoEnterprise::SubTenant.find_one(params[:id])
     end
 
     # POST /mnoe/jpi/v1/admin/sub_tenants
@@ -28,9 +26,22 @@ module MnoEnterprise
     def update
       @sub_tenant = MnoEnterprise::SubTenant.find_one(params[:id])
       @sub_tenant.update!(sub_tenant_params)
-      @sub_tenant = @sub_tenant.load_required(:clients, :account_managers)
-      @sub_tenant_clients = @sub_tenant.clients
-      @sub_tenant_account_managers = @sub_tenant.account_managers
+      render :show
+    end
+
+    # PATCH /mnoe/jpi/v1/admin/organizations/1/update_clients
+    def update_clients
+      @sub_tenant = MnoEnterprise::SubTenant.find_one(params[:id])
+      attributes = params.require(:sub_tenant).permit(add: [], remove: [])
+      @sub_tenant.update_clients!({data: {attributes: attributes}})
+      render :show
+    end
+
+    # PATCH /mnoe/jpi/v1/admin/organizations/1/update_account_managers
+    def update_account_managers
+      @sub_tenant = MnoEnterprise::SubTenant.find_one(params[:id])
+      attributes = params.require(:sub_tenant).permit(add: [], remove: [])
+      @sub_tenant.update_account_managers!({data: {attributes: attributes}})
       render :show
     end
 
@@ -47,11 +58,7 @@ module MnoEnterprise
 
     private
     def sub_tenant_params
-      sub_tenant_params = params.require(:sub_tenant)
-      allowed_params = sub_tenant_params.permit(:name, client_ids: [], account_manager_ids: [])
-      allowed_params[:client_ids] ||= [] if sub_tenant_params.has_key?(:client_ids)
-      allowed_params[:account_manager_ids] ||= [] if sub_tenant_params.has_key?(:account_manager_ids)
-      allowed_params
+      params.require(:sub_tenant).permit(:name)
     end
   end
 end

--- a/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_organization.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_organization.json.jbuilder
@@ -1,1 +1,2 @@
-json.extract! organization, :id, :name, :uid, :soa_enabled, :created_at, :account_frozen, :financial_metrics, :billing_currency, :external_id
+json.extract! organization, :id, :name, :uid, :soa_enabled, :created_at, :account_frozen, :financial_metrics, :billing_currency, :external_id, :belong_to_sub_tenant, :belong_to_account_manager
+

--- a/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/_sub_tenant.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/_sub_tenant.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! sub_tenant, :id, :name, :created_at, :updated_at, :client_ids, :account_manager_ids
+json.extract! sub_tenant, :id, :name, :created_at, :updated_at

--- a/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/index.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/index.json.jbuilder
@@ -1,2 +1,1 @@
 json.sub_tenants @sub_tenants, partial: 'sub_tenant', as: :sub_tenant
-json.metadata @sub_tenants.metadata if @sub_tenants.respond_to?(:metadata)

--- a/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/sub_tenants/show.json.jbuilder
@@ -1,12 +1,3 @@
 json.sub_tenant do
   json.partial! 'sub_tenant', sub_tenant: @sub_tenant
-
-  json.clients @sub_tenant_clients do |org|
-    json.extract! org, :id, :uid, :name, :created_at
-  end
-
-  json.account_managers @sub_tenant_account_managers do |user|
-    json.extract! user, :id, :uid, :name, :surname, :email, :created_at, :admin_role
-  end
-
 end

--- a/api/app/views/mno_enterprise/jpi/v1/admin/users/_user.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/users/_user.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! user, :id, :uid, :email, :phone, :name, :surname, :admin_role, :created_at, :updated_at, :confirmed_at, :last_sign_in_at, :sign_in_count, :client_ids
-json.mnoe_sub_tenant_id user.sub_tenant_id
+json.extract! user, :id, :uid, :email, :phone, :name, :surname, :admin_role, :created_at, :updated_at, :confirmed_at, :last_sign_in_at, :sign_in_count
+json.sub_tenant_id user.sub_tenant&.id
 json.access_request_status user.access_request_status(current_user)

--- a/api/app/views/mno_enterprise/jpi/v1/admin/users/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/users/show.json.jbuilder
@@ -4,8 +4,4 @@ json.user do
   json.organizations @user_organizations do |org|
     json.extract! org, :id, :uid, :name, :account_frozen, :created_at
   end
-
-  json.clients @user_clients do |org|
-    json.extract! org, :id, :uid, :name, :account_frozen, :created_at
-  end
 end

--- a/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
@@ -17,7 +17,7 @@ json.cache! ['v2', @user.cache_key] do
     json.admin_role @user.admin_role
     json.avatar_url avatar_url(@user)
     json.settings @user.settings
-    json.mnoe_sub_tenant_id @user.sub_tenant_id
+    json.sub_tenant_id @user.sub_tenant&.id
 
     if current_impersonator
       json.current_impersonator true

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -220,6 +220,9 @@ MnoEnterprise::Engine.routes.draw do
             post :signup_email
           end
           resource :user_access_requests, only: [:create]
+          member do
+            patch :update_clients
+          end
         end
 
         resources :products, only: [:index, :show]
@@ -266,7 +269,12 @@ MnoEnterprise::Engine.routes.draw do
           end
         end
 
-        resources :sub_tenants, only: [:index, :show, :destroy, :update, :create]
+        resources :sub_tenants, only: [:index, :show, :destroy, :update, :create] do
+          member do
+            patch :update_clients
+            patch :update_account_managers
+          end
+        end
 
         resources :tenant_invoices, only: [:index, :show]
 

--- a/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
@@ -9,7 +9,7 @@ module MnoEnterprise
     let(:user2) { build(:user) }
     before do
       stub_user(user)
-      stub_api_v2(:get, "/users/#{user2.id}", user2, %i(deletion_requests organizations orga_relations dashboards teams user_access_requests))
+      stub_api_v2(:get, "/users/#{user2.id}", user2, %i(deletion_requests organizations orga_relations dashboards teams user_access_requests sub_tenant))
 
       stub_api_v2(:patch, "/users/#{user.id}")
       stub_api_v2(:patch, "/users/#{user2.id}")
@@ -37,7 +37,7 @@ module MnoEnterprise
         end
 
         context 'when the user does not exist' do
-          before { stub_api_v2(:get, '/users/crappyId', [], %i(deletion_requests organizations orga_relations dashboards teams user_access_requests)) }
+          before { stub_api_v2(:get, '/users/crappyId', [], %i(deletion_requests organizations orga_relations dashboards teams user_access_requests sub_tenant)) }
           subject { get :create, user_id: 'crappyId', dhbRefId: 10 }
           it do
             is_expected.to redirect_to('/admin/#!?flash=%7B%22msg%22%3A%22User+does+not+exist%22%2C%22type%22%3A%22error%22%7D')

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -32,7 +32,8 @@ module MnoEnterprise
         {
           organizations: [
             :uid, :name, :account_frozen, :soa_enabled, :mails, :logo, :latitude, :longitude, :geo_country_code, :geo_state_code,
-            :geo_city, :geo_tz, :geo_currency, :metadata, :industry, :size, :financial_year_end_month, :credit_card, :financial_metrics, :created_at, :external_id
+            :geo_city, :geo_tz, :geo_currency, :metadata, :industry, :size, :financial_year_end_month, :credit_card, :financial_metrics, :created_at, :external_id,
+            :belong_to_sub_tenant, :belong_to_account_manager
           ].join(',')
         }
       end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
@@ -14,12 +14,7 @@ module MnoEnterprise
     end
 
     def hash_for_sub_tenant(s)
-      hash = partial_hash_for_sub_tenant(s).merge(
-        {
-          'clients' => s.clients.map { |c| hash_for_client(c) },
-          'account_managers' => s.account_managers.map { |c| hash_account_manager(c) },
-        })
-      { 'sub_tenant' => hash }
+      { 'sub_tenant' => partial_hash_for_sub_tenant(s) }
     end
 
     def partial_hash_for_sub_tenant(s)
@@ -27,30 +22,7 @@ module MnoEnterprise
         'id' => s.id,
         'name' => s.name,
         'created_at' => s.created_at,
-        'updated_at' => s.updated_at,
-        'client_ids' => s.client_ids,
-        'account_manager_ids' => s.account_manager_ids
-      }
-    end
-
-    def hash_for_client(client)
-      {
-        'id' => client.id,
-        'uid' => client.uid,
-        'name' => client.name,
-        'created_at' => client.created_at
-      }
-    end
-
-    def hash_account_manager(user)
-      {
-        'id' => user.id,
-        'uid' => user.uid,
-        'name' => user.name,
-        'surname' => user.surname,
-        'email' => user.email,
-        'created_at' => user.created_at,
-        'admin_role' => user.admin_role
+        'updated_at' => s.updated_at
       }
     end
 
@@ -66,9 +38,7 @@ module MnoEnterprise
     # Specs
     #===============================================
     let!(:user) { build(:user, :admin) }
-    let(:account_manager) { build(:user) }
-    let(:client) { build(:organization) }
-    let(:sub_tenant) { build(:sub_tenant, account_managers: [account_manager], clients: [client]) }
+    let(:sub_tenant) { build(:sub_tenant) }
     let!(:current_user_stub) { stub_user(user) }
 
     describe '#index' do
@@ -96,7 +66,7 @@ module MnoEnterprise
       subject { get :show, id: sub_tenant.id }
 
       before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant, %i(clients account_managers))
+        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
       end
       context 'not admin' do
         let!(:user) { build(:user) }
@@ -121,7 +91,6 @@ module MnoEnterprise
       subject { put :update, id: sub_tenant.id, sub_tenant: { name: 'new name' } }
       before do
         stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant, %i(clients account_managers))
         sign_in user
       end
       let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
@@ -138,6 +107,49 @@ module MnoEnterprise
         end
       end
     end
+
+    describe 'PATCH #update_clients' do
+      subject { put :update_clients, id: sub_tenant.id, sub_tenant: { add: [] } }
+      before do
+        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
+        sign_in user
+      end
+      let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}/update_clients", sub_tenant) }
+      context 'not admin' do
+        let!(:user) { build(:user) }
+        it_behaves_like 'unauthorized access'
+      end
+      it_behaves_like 'a jpi v1 admin action'
+      context 'admin' do
+        context 'success' do
+          before { subject }
+          it { expect(response).to be_success }
+          it { expect(stub).to have_been_requested }
+        end
+      end
+    end
+
+    describe 'PATCH #update_account_managers' do
+      subject { put :update_account_managers, id: sub_tenant.id, sub_tenant: { add: [] } }
+      before do
+        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
+        sign_in user
+      end
+      let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}/update_account_managers", sub_tenant) }
+      context 'not admin' do
+        let!(:user) { build(:user) }
+        it_behaves_like 'unauthorized access'
+      end
+      it_behaves_like 'a jpi v1 admin action'
+      context 'admin' do
+        context 'success' do
+          before { subject }
+          it { expect(response).to be_success }
+          it { expect(stub).to have_been_requested }
+        end
+      end
+    end
+
     describe 'DELETE #destroy' do
       subject { delete :destroy, id: sub_tenant.id }
       before do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/current_users_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/current_users_controller_spec.rb
@@ -35,7 +35,7 @@ module MnoEnterprise
         'admin_role' => res.admin_role,
         'avatar_url' => avatar_url(res),
         'settings' => res.settings,
-        'mnoe_sub_tenant_id' => res.sub_tenant_id,
+        'sub_tenant_id' => res.sub_tenant&.id,
         'user_hash' => res.intercom_user_hash
       }
 
@@ -108,7 +108,7 @@ module MnoEnterprise
 
         it 'returns the right response' do
           subject
-          expect(response.body).to eq(json_for(user))
+          expect(JSON.parse(response.body)).to eq(json_hash_for(user))
         end
       end
     end

--- a/core/app/helpers/mno_enterprise/impersonate_helper.rb
+++ b/core/app/helpers/mno_enterprise/impersonate_helper.rb
@@ -22,7 +22,7 @@ module MnoEnterprise
 
     def current_impersonator
       return unless session[:impersonator_user_id]
-      @admin_user ||= MnoEnterprise::User.find_one(session[:impersonator_user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams)
+      @admin_user ||= MnoEnterprise::User.find_one(session[:impersonator_user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams, :sub_tenant)
     end
 
   end

--- a/core/app/models/mno_enterprise/sub_tenant.rb
+++ b/core/app/models/mno_enterprise/sub_tenant.rb
@@ -3,7 +3,18 @@ module MnoEnterprise
     property :created_at, type: :time
     property :updated_at, type: :time
     property :name
-    property :account_manager_ids
-    property :client_ids
+
+    custom_endpoint :update_clients, on: :member, request_method: :patch
+    custom_endpoint :update_account_managers, on: :member, request_method: :patch
+
+    def update_clients!(input)
+      result = self.update_clients(input)
+      process_custom_result(result)
+    end
+
+    def update_account_managers!(input)
+      result = self.update_account_managers(input)
+      process_custom_result(result)
+    end
   end
 end

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -7,7 +7,7 @@ module MnoEnterprise
     include ActiveModel::AttributeMethods
     include ActiveModel::Validations
 
-    INCLUDED_DEPENDENCIES = %i(deletion_requests organizations orga_relations dashboards teams)
+    INCLUDED_DEPENDENCIES = %i(deletion_requests organizations orga_relations dashboards teams sub_tenant)
 
     # ids
     property :id
@@ -41,8 +41,7 @@ module MnoEnterprise
     property :surname, type: :string
     property :website, type: :string
 
-    property :sub_tenant_id, type: :string
-    property :client_ids
+    has_one :sub_tenant
 
     define_model_callbacks :validation #required by Devise
     define_model_callbacks :update #required by Devise
@@ -77,6 +76,7 @@ module MnoEnterprise
     custom_endpoint :create_api_credentials, on: :member, request_method: :patch
     custom_endpoint :authenticate, on: :collection, request_method: :post
     custom_endpoint :update_password, on: :member, request_method: :patch
+    custom_endpoint :update_clients, on: :member, request_method: :patch
 
     #================================
     # Class Methods
@@ -147,6 +147,11 @@ module MnoEnterprise
 
     def create_api_credentials!
       result = create_api_credentials
+      process_custom_result(result)
+    end
+
+    def update_clients!(input)
+      result = update_clients(input)
       process_custom_result(result)
     end
 

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -35,6 +35,8 @@ module MnoEnterprise::Concerns::Models::Organization
     property :financial_metrics
     property :billing_currency
     property :external_id, type: :string
+    property :belong_to_sub_tenant, type: :boolean
+    property :belong_to_account_manager, type: :boolean
   end
 
   #==================================================================

--- a/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
+++ b/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
@@ -51,7 +51,7 @@ module MnoEnterpriseApiTestHelper
   end
 
   def stub_user(user)
-    stub_api_v2(:get, "/users/#{user.id}", user, %i(deletion_requests organizations orga_relations dashboards teams))
+    stub_api_v2(:get, "/users/#{user.id}", user, %i(deletion_requests organizations orga_relations dashboards teams sub_tenant))
   end
 
   def api_v2_url(suffix, included = [], params = {})


### PR DESCRIPTION
- remove clients and account_managers dependency from sub_tenant
- remove clients dependeny from user
- introduce update_clients and update_account_managers endpoint
- replace user.mnoe_sub_tenant_id by sub_tenant_id
- add optional belong_to_subtenant and belong_to_account_manager boolean parameter depending on the sub_tenant_id and account_manager parameter