### PR TITLE
[MNO-695] Api v2 Dashboard missing dependency for KPI Alert Recipients

### DIFF
--- a/api/app/views/mno_enterprise/jpi/v1/impac/alerts/_alert.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/impac/alerts/_alert.json.jbuilder
@@ -1,7 +1,6 @@
 json.ignore_nil!
-json.extract! alert, :id, :title, :webhook, :service, :sent
+json.extract! alert, :id, :title, :webhook, :service, :sent, :kpi_id
 json.metadata alert.settings
-json.kpi_id alert.kpi_id
 json.recipients alert.recipients.map do |recipient|
   json.extract! recipient, :id, :email
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/alerts_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/alerts_controller.rb
@@ -12,8 +12,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::AlertsController
 
   # GET /jpi/v1/impac/alerts
   def index
-    u = current_user.load_required(:alerts)
-    @alerts = u.alerts
+    @alerts = MnoEnterprise::Alert.includes(:recipients).where('recipient.id' => current_user.id)
   end
 
   # POST /jpi/v1/impac/kpis/:kpi_id/alerts
@@ -23,8 +22,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::AlertsController
 
     # TODO: Manage authorization
     #authorize! :manage_alert, kpi_alert
-
-    @alert = MnoEnterprise::Alert.create!(alert_params.merge(recipient_ids: [current_user.id]))
+    @alert = MnoEnterprise::Alert.create!(alert_params)
+    @alert.update_recipients!([current_user.id])
+    @alert = @alert.load_required(:recipients)
     render 'show'
   end
 

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
@@ -10,7 +10,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     respond_to :json
   end
 
-  DASHBOARD_DEPENDENCIES = [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts']
+  DASHBOARD_DEPENDENCIES = [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts', :'kpis.alerts.recipients']
 
   #==================================================================
   # Instance methods
@@ -29,9 +29,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
   # POST /mnoe/jpi/v1/impac/dashboards
   #   -> POST /api/mnoe/v1/users/1/dashboards
   def create
-    # TODO: dashboards.build breaks as dashboard.organization_ids returns nil, instead of an
-    #       empty array. (see MnoEnterprise::Impac::Dashboard #organizations)
-    # @dashboard = dashboards.build(dashboard_create_params)
     # TODO: enable authorization
     # authorize! :manage_dashboard, @dashboard
     # if @dashboard.save

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -25,9 +25,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
     auth = { username: MnoEnterprise.tenant_id, password: MnoEnterprise.tenant_key }
 
     begin
+      # TODO check there was no error, something like
+      # return render json: { message: "Unable to retrieve kpis from Impac API | Error #{response.code}" } unless response.success?
       response = MnoEnterprise::ImpacClient.send_get('/api/v2/kpis', attrs, basic_auth: auth)
-        # TODO check there was no error, something like
-        # return render json: { message: "Unable to retrieve kpis from Impac API | Error #{response.code}" } unless response.success?
     rescue => e
       return render json: { message: "Unable to retrieve kpis from Impac API | Error #{e}" }
     end
@@ -42,8 +42,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
           target_placeholders: { watchable => kpi[:target_placeholders][watchable] },
         )
       end
-    end
-             .flatten
+    end.flatten
 
     render json: { kpis: kpis }
   end
@@ -85,7 +84,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
     # Creates an in-app alert if target is set for the first time (in-app alerts should be activated by default)
     if kpi.targets.blank? && params[:targets].present?
       MnoEnterprise::Alert.create_with_recipients!({ service: 'inapp', kpi_id: kpi.id }, [current_user.id])
-    # If targets have changed, reset all the alerts 'sent' status to false.
+      # If targets have changed, reset all the alerts 'sent' status to false.
     elsif kpi.targets && params[:targets].present? && params[:targets] != kpi.targets
       kpi.alerts.each { |alert| alert.update_attributes(sent: false) }
       # Removes all the alerts if the targets are removed (kpi has no targets set,

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
@@ -8,7 +8,7 @@ module MnoEnterprise
     before { request.env["HTTP_ACCEPT"] = 'application/json' }
     before { Rails.cache.clear }
 
-    let(:dashboard_dependencies) { [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts'] }
+    let(:dashboard_dependencies) { [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts', :'kpis.alerts.recipients'] }
 
     # Stub user and user call
     let(:org) { build(:organization, users: [], orga_relations: []) }
@@ -104,7 +104,7 @@ module MnoEnterprise
 
     describe 'GET #show' do
       before do
-        stub_api_v2(:get, "/dashboards/#{dashboard.id}", dashboard, [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts'], { filter: { owner_id: user.id } })
+        stub_api_v2(:get, "/dashboards/#{dashboard.id}", dashboard, dashboard_dependencies, {filter: {owner_id: user.id}})
       end
 
       subject { get :show, id: dashboard.id }

--- a/core/app/models/mno_enterprise/alert.rb
+++ b/core/app/models/mno_enterprise/alert.rb
@@ -2,5 +2,22 @@ module MnoEnterprise
   class Alert < BaseResource
     property :created_at, type: :time
     property :updated_at, type: :time
+    property :kpi_id
+    has_one :kpi
+
+    custom_endpoint :update_recipients, on: :member, request_method: :patch
+
+    def self.create_with_recipients!(attributes, recipient_ids)
+      alert = create(attributes)
+      alert.update_recipients!(recipient_ids)
+      alert
+    end
+
+    def update_recipients!(ids)
+      input = {data: {attributes: {set: ids}}}
+      result = update_recipients(input)
+      process_custom_result(result)
+    end
+
   end
 end

--- a/core/lib/mno_enterprise/testing_support/factories/impac/alerts.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/impac/alerts.rb
@@ -7,9 +7,9 @@ FactoryGirl.define do
       kpi_id '1'
       service 'inapp'
       title 'Test Alert'
-      recipients [{id: 1, email: 'test@maestrano.com'}]
       webhook 'webhook'
       sent false
+      recipients []
       settings {}
     end
   end

--- a/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
+++ b/core/lib/mno_enterprise/testing_support/mno_enterprise_api_test_helper.rb
@@ -148,14 +148,15 @@ module MnoEnterpriseApiTestHelper
 
     # Generate first and second level inclusions. E.g. includes='app_instances.app'
     # The second level entities get added to the included_entities hash
-    included_entities.values.each { |obj, inclusions| serialize_data(obj, inclusions, included_entities) }
+    # only taking the first level of inclusions
+    included_entities.values.each { |obj, inclusions| serialize_data(obj, inclusions[0,1], included_entities) }
 
     {
       data: data,
       meta: {
         record_count: entity_count(entity)
       },
-      included: included_entities.values.map { |obj, inclusions| serialize_data(obj, inclusions, included_entities) }
+      included: included_entities.values.map { |obj, inclusions| serialize_data(obj, inclusions[0,1], included_entities) }
     }
   end
 end


### PR DESCRIPTION
- Include Recipients in Alerts
- Use update_recipients instead of recipient_id