### PR TITLE
Add mnoe:update_all tasks to update all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ bin/rake mnoe:frontend:install_dependencies
 
 ## Upgrade
 
+To quickly upgrade all the components in your project you can run `bin/rake mnoe:update_all`.
+
 We follow [Semantic Versioning](https://semver.org/) so upgrading to a compatible version should be straightforward.
 
 For major upgrade between versions see [UPGRADING](UPGRADING.md).

--- a/frontend/lib/tasks/mnoe.rake
+++ b/frontend/lib/tasks/mnoe.rake
@@ -1,0 +1,46 @@
+require 'fileutils'
+
+# TODO: display more info about versioning
+# TODO: DRY frontend/admin tasks + specs
+namespace :mnoe do
+  #================================================================
+  # Helper methods
+  #================================================================
+  def admin_panel_installed?
+    File.foreach('yarn.lock').grep(/mnoe-admin-panel/).any?
+  end
+
+  def summary
+    puts '==> Your project has been upgraded'
+    puts '- mno-enterprise has been updated'
+    puts '- mno-enterprise-angular has been updated and the frontend rebuilt'
+    puts '- mnoe-admin-panel has been updated and the admin-panel rebuilt' if admin_panel_installed?
+    puts
+    puts 'To commit your changes:'
+    puts '- Commit the packages:'
+    puts '  $ git add -u *.lock'
+    puts '  $ git commit -m "Bump packages"'
+    puts '- Commit the build:'
+    puts '  $ git add public/dashboard public/admin'
+    puts '  $ git commit -m "Rebuild frontend"'
+  end
+
+  #================================================================
+  # Tasks
+  #================================================================
+  desc 'Perform a full upgrade and rebuild of this mnoe project'
+  task :update_all do
+    puts '==> Updating the mno-enterprise gem'
+    sh 'bundle update mno-enterprise --quiet'
+
+    puts '==> Updating and rebuilding the Dashboard'
+    Rake::Task['mnoe:frontend:update'].invoke
+
+    if admin_panel_installed?
+      puts '==> Updating and rebuilding the Admin Panel'
+      Rake::Task['mnoe:admin:update'].invoke
+    end
+
+    summary
+  end
+end


### PR DESCRIPTION
Simple task to peform all the build tasks at once:
```bash
∫ bin/rake mnoe:update_all
==> Updating the mno-enterprise gem
...
==> Updating and rebuilding the Dashboard
...
==> Updating and rebuilding the Admin Panel
...
==> Your project has been upgraded
- mno-enterprise has been updated
- mno-enterprise-angular has been updated and the frontend rebuilt
- mnoe-admin-panel has been updated and the admin-panel rebuilt

To commit your changes:
- Commit the packages:
  $ git add -u *.lock
  $ git commit -m "Bump packages"
- Commit the build:
  $ git add public/dashboard public/admin
  $ git commit -m "Rebuild frontend"
```