### PR TITLE
[MNOE-688] Generate getter and setter for has_one relationship

### DIFF
--- a/api/app/controllers/mno_enterprise/impersonate_controller.rb
+++ b/api/app/controllers/mno_enterprise/impersonate_controller.rb
@@ -9,7 +9,7 @@ module MnoEnterprise
     # GET /impersonate/user/123
     def create
       session[:impersonator_redirect_path] = params[:redirect_path].presence
-      @user = MnoEnterprise::User.find_one(params[:user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams, :user_access_requests, :sub_tenant)
+      @user = MnoEnterprise::User.find_one(params[:user_id], :user_access_requests)
       unless @user.present?
         return redirect_with_error('User does not exist')
       end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/app_answers_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/app_answers_controller.rb
@@ -10,7 +10,7 @@ module MnoEnterprise
 
     def app_answer_params
       # for an admin, the organization does not matter
-      orga_relation = current_user.orga_relations.first
+      orga_relation = MnoEnterprise::OrgaRelation.where('user.id': current_user.id).first
       params.require(:app_answer).permit(:description)
         .merge(reviewer_id: orga_relation.id, reviewer_type: 'OrgaRelation',
                parent_id: parent.id, reviewable_id: parent.reviewable_id, reviewable_type: 'App')

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/app_comments_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/app_comments_controller.rb
@@ -13,7 +13,7 @@ module MnoEnterprise
 
     def app_comment_params
       # for an admin, the organization does not matter
-      orga_relation = current_user.orga_relations.first
+      orga_relation = MnoEnterprise::OrgaRelation.where('user.id': current_user.id).first
       params.require(:app_comment).permit(:description)
         .merge(reviewer_id: orga_relation.id, reviewer_type: 'OrgaRelation',
                parent_id: parent.id, reviewable_id: parent.reviewable_id, reviewable_type: 'App')

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/app_instances_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/app_instances_controller.rb
@@ -3,7 +3,7 @@ module MnoEnterprise
 
     # DELETE /mnoe/jpi/v1/app_instances/1
     def destroy
-      app_instance = MnoEnterprise::AppInstance.find_one(params[:id])
+      app_instance = MnoEnterprise::AppInstance.find_one(params[:id], :owner)
 
       if app_instance
         MnoEnterprise::EventLogger.info('app_destroy', current_user.id, 'App destroyed', app_instance)

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
@@ -59,7 +59,7 @@ module MnoEnterprise
     private
 
     def load_organizations
-      @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+      @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
     end
 
     def whitelisted_params

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
@@ -1,8 +1,6 @@
 module MnoEnterprise
   class Jpi::V1::Admin::Impac::DashboardTemplatesController < Jpi::V1::Admin::BaseResourceController
 
-    before_action :load_organizations, except: [:destroy]
-
     # TODO [APIV2]: [:'widgets.kpis', :'kpis.alerts']
     DASHBOARD_DEPENDENCIES = [:widgets, :kpis]
 
@@ -36,6 +34,7 @@ module MnoEnterprise
       @dashboard_template.save!
       MnoEnterprise::EventLogger.info('dashboard_template_create', current_user.id, 'Dashboard Template Creation', @dashboard_template)
       @dashboard_template = @dashboard_template.load_required(*DASHBOARD_DEPENDENCIES)
+      load_organizations
       render 'show'
     end
 
@@ -45,6 +44,7 @@ module MnoEnterprise
       dashboard_template.update!(dashboard_template_params)
       @dashboard_template = @dashboard_template.load_required(*DASHBOARD_DEPENDENCIES)
       MnoEnterprise::EventLogger.info('dashboard_template_update', current_user.id, 'Dashboard Template Update', @dashboard_template)
+      load_organizations
       render 'show'
     end
 

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
@@ -26,6 +26,7 @@ module MnoEnterprise
     # GET /mnoe/jpi/v1/admin/impac/dashboard_templates/1
     def show
       @dashboard_template = MnoEnterprise::Dashboard.find_one!(params[:id], *DASHBOARD_DEPENDENCIES)
+      load_organizations
     end
 
     # POST /mnoe/jpi/v1/admin/impac/dashboard_templates

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller.rb
@@ -1,6 +1,8 @@
 module MnoEnterprise
   class Jpi::V1::Admin::Impac::DashboardTemplatesController < Jpi::V1::Admin::BaseResourceController
 
+    before_action :load_organizations, except: [:destroy]
+
     # TODO [APIV2]: [:'widgets.kpis', :'kpis.alerts']
     DASHBOARD_DEPENDENCIES = [:widgets, :kpis]
 
@@ -9,6 +11,7 @@ module MnoEnterprise
     #==================================================================
     # GET /mnoe/jpi/v1/admin/impac/dashboard_templates
     def index
+      dashboard_templates = MnoEnterprise::Dashboard.templates.includes(*DASHBOARD_DEPENDENCIES)
       if params[:terms]
         # For search mode
         @dashboard_templates = []
@@ -19,61 +22,44 @@ module MnoEnterprise
         @dashboard_templates = query.to_a
         response.headers['X-Total-Count'] = query.meta.record_count
       end
+      load_organizations
     end
 
     # GET /mnoe/jpi/v1/admin/impac/dashboard_templates/1
     def show
-      render json: { errors: { message: 'Dashboard template not found' } }, status: :not_found unless dashboard_template.present?
+      @dashboard_template = MnoEnterprise::Dashboard.find_one!(params[:id], *DASHBOARD_DEPENDENCIES)
     end
 
     # POST /mnoe/jpi/v1/admin/impac/dashboard_templates
     def create
       @dashboard_template = MnoEnterprise::Dashboard.new(dashboard_template_params.merge(dashboard_type: 'template'))
-
-      # Abort on failure
-      unless @dashboard_template.save
-        return render json: { errors: dashboard_template.errors }, status: :bad_request
-      end
-
-      MnoEnterprise::EventLogger.info('dashboard_template_create', current_user.id, 'Dashboard Template Creation', dashboard_template)
+      @dashboard_template.save!
+      MnoEnterprise::EventLogger.info('dashboard_template_create', current_user.id, 'Dashboard Template Creation', @dashboard_template)
+      @dashboard_template = @dashboard_template.load_required(*DASHBOARD_DEPENDENCIES)
       render 'show'
     end
 
     # PATCH/PUT /mnoe/jpi/v1/admin/impac/dashboard_templates/1
     def update
-      return render json: { errors: { message: 'Dashboard template not found' } }, status: :not_found unless dashboard_template
-
-      # Abort on failure
-      unless dashboard_template.update(dashboard_template_params)
-        return render json: { errors: dashboard_template.errors }, status: :bad_request
-      end
-
-      MnoEnterprise::EventLogger.info('dashboard_template_update', current_user.id, 'Dashboard Template Update', dashboard_template)
+      @dashboard_template = MnoEnterprise::Dashboard.find_one!(params[:id])
+      dashboard_template.update!(dashboard_template_params)
+      @dashboard_template = @dashboard_template.load_required(*DASHBOARD_DEPENDENCIES)
+      MnoEnterprise::EventLogger.info('dashboard_template_update', current_user.id, 'Dashboard Template Update', @dashboard_template)
       render 'show'
     end
 
     # DELETE /mnoe/jpi/v1/admin/impac/dashboard_templates/1
     def destroy
-      return render json: { errors: { message: 'Dashboard template not found' } }, status: :not_found unless dashboard_template
-
-      MnoEnterprise::EventLogger.info('dashboard_template_delete', current_user.id, 'Dashboard Template Deletion', dashboard_template)
-
-      # Abort on failure
-      unless dashboard_template.destroy
-        return render json: { errors: 'Cannot destroy dashboard template' }, status: :bad_request
-      end
-
+      @dashboard_template = MnoEnterprise::Dashboard.find_one!(params[:id])
+      MnoEnterprise::EventLogger.info('dashboard_template_delete', current_user.id, 'Dashboard Template Deletion', @dashboard_template)
+      @dashboard_template.destroy!
       head status: :ok
     end
 
     private
 
-    def dashboard_templates
-      @dashboard_templates ||= MnoEnterprise::Dashboard.templates.includes(*DASHBOARD_DEPENDENCIES)
-    end
-
-    def dashboard_template
-      @dashboard_template ||= dashboard_templates.find(params[:id].to_i).first
+    def load_organizations
+      @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
     end
 
     def whitelisted_params
@@ -86,7 +72,7 @@ module MnoEnterprise
       params.require(:dashboard).permit(*whitelisted_params).tap do |whitelisted|
         whitelisted[:settings] = params[:dashboard][:metadata] || {}
       end
-      .except(:metadata)
+        .except(:metadata)
     end
   end
 end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
@@ -210,7 +210,9 @@ module MnoEnterprise
       if params[:organization].key?(:app_nids) && (desired_nids = Array(params[:organization][:app_nids]))
         existing_apps = @organization.app_instances&.select(&:active?) || []
         existing_apps.each { |app_instance| desired_nids.delete(app_instance.app.nid) || app_instance.terminate }
-        desired_nids.each { |nid| @organization.provision_app_instance!(nid) }
+        desired_nids.each do |nid|
+          MnoEnterprise::AppInstance.provision!(nid, @organization.id, 'Organization' )
+        end
       end
     end
   end

--- a/api/app/controllers/mno_enterprise/jpi/v1/app_instances_sync_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/app_instances_sync_controller.rb
@@ -4,7 +4,7 @@ module MnoEnterprise
 
     # GET /mnoe/jpi/v1/organization/org-fbba/app_instances_sync
     def index
-      authorize! :check_apps_sync, @parent_organization
+      authorize! :check_apps_sync, orga_relation
       connectors = parent_organization.app_instances_sync!
       render json: results(connectors)
     end
@@ -12,7 +12,7 @@ module MnoEnterprise
 
     # POST /mnoe/jpi/v1/organizations/org-fbba/app_instances_sync
     def create
-      authorize! :sync_apps, @parent_organization
+      authorize! :sync_apps, orga_relation
       connectors = parent_organization.trigger_app_instances_sync!
       render json: results(connectors)
     end

--- a/api/app/controllers/mno_enterprise/jpi/v1/app_reviews_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/app_reviews_controller.rb
@@ -53,7 +53,7 @@ module MnoEnterprise
     end
 
     def orga_relation
-      @orga_relation ||= MnoEnterprise::OrgaRelation.where(organization_id: organization_id, user_id: current_user.id).first
+      @orga_relation ||= MnoEnterprise::OrgaRelation.where('organization.id': organization_id, 'user.id': current_user.id).first
     end
 
     def ensure_app_exists

--- a/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
@@ -3,6 +3,38 @@ module MnoEnterprise
     before_filter :check_authorization
 
     protected
+
+    # test if the provided argument is a id or an uid
+    # @param [Object] id or uid
+    def is_id?(string)
+      string.to_i.to_s == string
+    end
+
+    def parent_organization_id
+      id_or_uid = params[:organization_id]
+      if is_id?(id_or_uid)
+        id_or_uid
+      else
+        parent_organization.id
+      end
+    end
+
+    def parent_organization
+      @parent_organization ||= begin
+        id_or_uid = params[:organization_id]
+        query = is_id?(id_or_uid) ? id_or_uid : { uid: id_or_uid }
+        MnoEnterprise::Organization.find(query).first
+      end
+    end
+
+    def orga_relation
+      @orga_relation ||= begin
+        id_or_uid = params[:organization_id]
+        organization_field = is_id?(id_or_uid) ? 'id' : 'uid'
+        MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, "organization.#{organization_field}" => id_or_uid).first
+      end
+    end
+
     # Check current user is logged in
     # Check organization is valid if specified
     def check_authorization

--- a/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
@@ -3,36 +3,6 @@ module MnoEnterprise
     before_filter :check_authorization
 
     protected
-    def is_id?(string)
-      # we consider that it is an id, if it's
-      string.to_i.to_s == string
-    end
-
-    def orga_relation
-      @orga_relation ||= begin
-        id_or_uid = params[:organization_id]
-        organization_field = is_id?(id_or_uid) ? 'id' : 'uid'
-        MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, "organization.#{organization_field}" => id_or_uid).first
-      end
-    end
-
-    def parent_organization_id
-      id_or_uid = params[:organization_id]
-      if is_id?(id_or_uid)
-        id_or_uid
-      else
-        parent_organization.id
-      end
-    end
-
-    def parent_organization
-      @parent_organization ||= begin
-        id_or_uid = params[:organization_id]
-        query = is_id?(id_or_uid) ? id_or_uid : { uid: id_or_uid }
-        MnoEnterprise::Organization.find(query).first
-      end
-    end
-
     # Check current user is logged in
     # Check organization is valid if specified
     def check_authorization

--- a/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
@@ -3,50 +3,61 @@ module MnoEnterprise
     before_filter :check_authorization
 
     protected
+    def is_id?(string)
+      # we consider that it is an id, if it's
+      string.to_i.to_s == string
+    end
 
-      def timestamp
-        @timestamp ||= (params[:timestamp] || 0).to_i
+    def orga_relation
+      @orga_relation ||= begin
+        id_or_uid = params[:organization_id]
+        organization_field = is_id?(id_or_uid) ? 'id' : 'uid'
+        MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, "organization.#{organization_field}" => id_or_uid).first
       end
+    end
 
-      def is_integer?(string)
-        string.to_i.to_s == string
+    def parent_organization_id
+      id_or_uid = params[:organization_id]
+      if is_id?(id_or_uid)
+        id_or_uid
+      else
+        parent_organization.id
       end
+    end
 
-      def parent_organization
-        @parent_organization ||= begin
-          id_or_uid = params[:organization_id]
-          query = is_integer?(id_or_uid) ? id_or_uid : {uid: id_or_uid}
-          o = MnoEnterprise::Organization.includes(:orga_relations, :users).find(query).first
-          ## check that user is in the organization
-          o if o && o.orga_relation(current_user)
-        end
+    def parent_organization
+      @parent_organization ||= begin
+        id_or_uid = params[:organization_id]
+        query = is_id?(id_or_uid) ? id_or_uid : { uid: id_or_uid }
+        MnoEnterprise::Organization.find(query).first
       end
+    end
 
-      # Check current user is logged in
-      # Check organization is valid if specified
-      def check_authorization
-        unless current_user
-          render nothing: true, status: :unauthorized
-          return false
-        end
-        if params[:organization_id] && !parent_organization
-          render nothing: true, status: :forbidden
-          return false
-        end
-        true
+    # Check current user is logged in
+    # Check organization is valid if specified
+    def check_authorization
+      unless current_user
+        render nothing: true, status: :unauthorized
+        return false
       end
+      if params[:organization_id] && !orga_relation
+        render nothing: true, status: :forbidden
+        return false
+      end
+      true
+    end
 
-      def render_not_found(resource, id = params[:id])
-        render json: { errors: {message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params} }, status: :not_found
-      end
+    def render_not_found(resource, id = params[:id])
+      render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
+    end
 
-      def render_bad_request(attempted_action, issue)
-        issue = issue.full_messages if issue.respond_to?(:full_messages)
-        render json: { errors: {message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params} }, status: :bad_request
-      end
+    def render_bad_request(attempted_action, issue)
+      issue = issue.full_messages if issue.respond_to?(:full_messages)
+      render json: { errors: { message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params } }, status: :bad_request
+    end
 
-      def render_forbidden_request(attempted_action)
-        render json: { errors: {message: "Error while trying to #{attempted_action}: you do not have permission", code: 403} }, status: :forbidden
-      end
+    def render_forbidden_request(attempted_action)
+      render json: { errors: { message: "Error while trying to #{attempted_action}: you do not have permission", code: 403 } }, status: :forbidden
+    end
   end
 end

--- a/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
@@ -16,18 +16,5 @@ module MnoEnterprise
       end
       true
     end
-
-    def render_not_found(resource, id = params[:id])
-      render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
-    end
-
-    def render_bad_request(attempted_action, issue)
-      issue = issue.full_messages if issue.respond_to?(:full_messages)
-      render json: { errors: { message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params } }, status: :bad_request
-    end
-
-    def render_forbidden_request(attempted_action)
-      render json: { errors: { message: "Error while trying to #{attempted_action}: you do not have permission", code: 403 } }, status: :forbidden
-    end
   end
 end

--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboard_templates/_template.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboard_templates/_template.json.jbuilder
@@ -2,7 +2,7 @@ json.extract! template, :id, :name, :full_name, :currency
 
 json.metadata template.settings
 
-json.data_sources template.organizations(current_user.organizations).compact.map do |org|
+json.data_sources template.organizations(@organizations).compact.map do |org|
   json.id org.id
   json.uid org.uid
   json.label org.name

--- a/api/app/views/mno_enterprise/jpi/v1/impac/dashboards/_dashboard.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/impac/dashboards/_dashboard.json.jbuilder
@@ -2,7 +2,7 @@ json.extract! dashboard, :id, :name, :full_name, :currency
 
 json.metadata dashboard.settings
 
-json.data_sources dashboard.organizations(current_user.organizations).compact.map do |org|
+json.data_sources dashboard.organizations(@organizations).compact.map do |org|
   json.id org.id
   json.uid org.uid
   json.label org.name

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
@@ -22,16 +22,4 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::BaseResourceControl
     render nothing: true, status: :unauthorized
     false
   end
-
-  def render_not_found(resource = controller_name.singularize, id = params[:id])
-    render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
-  end
-
-  def render_bad_request(attempted_action, issue)
-    render json: { errors: { message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params } }, status: :bad_request
-  end
-
-  def render_forbidden_request(attempted_action)
-    render json: { errors: { message: "Error while trying to #{attempted_action}: you do not have permission", code: 403 } }, status: :forbidden
-  end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
@@ -12,11 +12,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::BaseResourceControl
   end
 
   protected
-
-  def timestamp
-    @timestamp ||= (params[:timestamp] || 0).to_i
-  end
-
+  
   # Check current user is logged in
   # Check organization is valid if specified
   def check_authorization
@@ -28,14 +24,14 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::BaseResourceControl
   end
 
   def render_not_found(resource = controller_name.singularize, id = params[:id])
-    render json: { errors: {message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params} }, status: :not_found
+    render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
   end
 
   def render_bad_request(attempted_action, issue)
-    render json: { errors: {message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params} }, status: :bad_request
+    render json: { errors: { message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params } }, status: :bad_request
   end
 
   def render_forbidden_request(attempted_action)
-    render json: { errors: {message: "Error while trying to #{attempted_action}: you do not have permission", code: 403} }, status: :forbidden
+    render json: { errors: { message: "Error while trying to #{attempted_action}: you do not have permission", code: 403 } }, status: :forbidden
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
@@ -12,7 +12,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::BaseResourceControl
   end
 
   protected
-  
   # Check current user is logged in
   # Check organization is valid if specified
   def check_authorization

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
@@ -16,7 +16,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::AppInstancesController
   # GET /mnoe/jpi/v1/organization/1/app_instances
   def index
     statuses = MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')
-    @app_instances = MnoEnterprise::AppInstance.includes(:app).where('owner.id': parent_organization.id, 'status.in': statuses, 'fulfilled_only': true).to_a.select do |i|
+    @app_instances = MnoEnterprise::AppInstance.includes(:app).where('owner.id': parent_organization_id, 'status.in': statuses, 'fulfilled_only': true).to_a.select do |i|
       can?(:access,i)
     end
   end
@@ -24,8 +24,8 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::AppInstancesController
   # POST /mnoe/jpi/v1/organization/1/app_instances
   def create
     authorize! :manage_app_instances, orga_relation
-    input = { data: { attributes: { app_nid: params[:nid], owner_id: parent_organization_id, owner_type: 'Organization' } } }
-    app_instance = MnoEnterprise::AppInstance.provision!(input)
+    app_instance = MnoEnterprise::AppInstance.provision!(params[:nid], parent_organization_id, 'Organization' )
+    app_instance = app_instance.load_required(:owner)
     MnoEnterprise::EventLogger.info('app_add', current_user.id, 'App added', app_instance)
     head :created
   end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
@@ -16,25 +16,25 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::AppInstancesController
   # GET /mnoe/jpi/v1/organization/1/app_instances
   def index
     statuses = MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')
-    @app_instances = MnoEnterprise::AppInstance.includes(:app).where(owner_id: parent_organization.id, 'status.in': statuses, 'fulfilled_only': true).to_a.select do |i|
+    @app_instances = MnoEnterprise::AppInstance.includes(:app).where('owner.id': parent_organization.id, 'status.in': statuses, 'fulfilled_only': true).to_a.select do |i|
       can?(:access,i)
     end
   end
 
   # POST /mnoe/jpi/v1/organization/1/app_instances
   def create
-    authorize! :manage_app_instances, parent_organization
-    app_instance = parent_organization.provision_app_instance!(params[:nid])
+    authorize! :manage_app_instances, orga_relation
+    input = { data: { attributes: { app_nid: params[:nid], owner_id: parent_organization_id, owner_type: 'Organization' } } }
+    app_instance = MnoEnterprise::AppInstance.provision!(input)
     MnoEnterprise::EventLogger.info('app_add', current_user.id, 'App added', app_instance)
     head :created
   end
 
   # DELETE /mnoe/jpi/v1/app_instances/1
   def destroy
-    @app_instance = MnoEnterprise::AppInstance.find_one(params[:id])
+    @app_instance = MnoEnterprise::AppInstance.find_one(params[:id], :owner)
     if @app_instance
-      organization = MnoEnterprise::Organization.find_one(@app_instance.owner_id)
-      authorize! :manage_app_instances, organization
+      authorize! :manage_app_instances,  current_user.orga_relation(@app_instance.owner)
       MnoEnterprise::EventLogger.info('app_destroy', current_user.id, 'App destroyed', @app_instance)
       @app_instance = @app_instance.terminate!
     end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/current_users_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/current_users_controller.rb
@@ -1,7 +1,7 @@
 module MnoEnterprise::Concerns::Controllers::Jpi::V1::CurrentUsersController
   extend ActiveSupport::Concern
 
-  INCLUDED_DEPENDENCIES = %i(deletion_requests organizations orga_relations dashboards teams orga_relations.user orga_relations.organization sub_tenant)
+  INCLUDED_DEPENDENCIES = %i(organizations orga_relations dashboards teams orga_relations.user orga_relations.organization sub_tenant)
 
   #==================================================================
   # Included methods
@@ -25,10 +25,10 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::CurrentUsersController
   # PUT /mnoe/jpi/v1/current_user
   def update
     current_user.attributes = user_params
-    changed_attributes = @user.changed_attributes
+    changed_attributes = current_user.changed_attributes
     current_user.save!
     current_user.refresh_user_cache
-    MnoEnterprise::EventLogger.info('user_update', current_user.id, 'User update', @user, changed_attributes)
+    MnoEnterprise::EventLogger.info('user_update', current_user.id, 'User update', current_user, changed_attributes)
     @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
     render :show
   end
@@ -36,16 +36,15 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::CurrentUsersController
   # PUT /mnoe/jpi/v1/current_user/register_developer
   def register_developer
     current_user.create_api_credentials!
-    MnoEnterprise::EventLogger.info('register_developer', current_user.id, 'Developer registration', @user)
+    MnoEnterprise::EventLogger.info('register_developer', current_user.id, 'Developer registration', current_user)
     @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
     render :show
-
   end
 
   # PUT /mnoe/jpi/v1/current_user/update_password
   def update_password
     current_user.update_password!(data: { attributes: password_params })
-    MnoEnterprise::EventLogger.info('user_update_password', current_user.id, 'User password change', @user)
+    MnoEnterprise::EventLogger.info('user_update_password', current_user.id, 'User password change', current_user)
     @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
     sign_in @user, bypass: true
     render :show

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/current_users_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/current_users_controller.rb
@@ -1,6 +1,8 @@
 module MnoEnterprise::Concerns::Controllers::Jpi::V1::CurrentUsersController
   extend ActiveSupport::Concern
 
+  INCLUDED_DEPENDENCIES = %i(deletion_requests organizations orga_relations dashboards teams orga_relations.user orga_relations.organization sub_tenant)
+
   #==================================================================
   # Included methods
   #==================================================================
@@ -17,55 +19,52 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::CurrentUsersController
   #==================================================================
   # GET /mnoe/jpi/v1/current_user
   def show
-    @user = current_user || MnoEnterprise::User.new(id: nil)
+    @user = current_user&.load_required(*INCLUDED_DEPENDENCIES) || MnoEnterprise::User.new(id: nil)
   end
 
   # PUT /mnoe/jpi/v1/current_user
   def update
-    @user = current_user
-    @user.attributes = user_params
+    current_user.attributes = user_params
     changed_attributes = @user.changed_attributes
-    @user.save!
-    MnoEnterprise::EventLogger.info('user_update', current_user.id, 'User update', @user, changed_attributes)
-    @user = @user.load_required_dependencies
-    render :show
+    current_user.save!
     current_user.refresh_user_cache
+    MnoEnterprise::EventLogger.info('user_update', current_user.id, 'User update', @user, changed_attributes)
+    @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
+    render :show
   end
 
   # PUT /mnoe/jpi/v1/current_user/register_developer
   def register_developer
-    @user = current_user
-    @user = @user.create_api_credentials!
+    current_user.create_api_credentials!
     MnoEnterprise::EventLogger.info('register_developer', current_user.id, 'Developer registration', @user)
-    @user = @user.load_required_dependencies
+    @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
     render :show
 
   end
 
   # PUT /mnoe/jpi/v1/current_user/update_password
   def update_password
-    @user = current_user
-    @user = @user.update_password!(data: {attributes: password_params})
+    current_user.update_password!(data: { attributes: password_params })
     MnoEnterprise::EventLogger.info('user_update_password', current_user.id, 'User password change', @user)
-    @user = @user.load_required_dependencies
+    @user = current_user.load_required(*INCLUDED_DEPENDENCIES)
     sign_in @user, bypass: true
     render :show
   end
 
   private
 
-    def user_params
-      params.require(:user).permit(
-        :name, :surname, :email, :company, :phone, :website, :phone_country_code, :current_password, :password, :password_confirmation,
-        settings: [:locale]
-      )
-    end
+  def user_params
+    params.require(:user).permit(
+      :name, :surname, :email, :company, :phone, :website, :phone_country_code, :current_password, :password, :password_confirmation,
+      settings: [:locale]
+    )
+  end
 
-    def password_params
-      params.require(:user).permit(:current_password, :password, :password_confirmation)
-    end
+  def password_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
 
-    def user_management_enabled?
-      return head :forbidden unless Settings.dashboard.user_management.enabled
-    end
+  def user_management_enabled?
+    return head :forbidden unless Settings.dashboard.user_management.enabled
+  end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/deletion_requests_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/deletion_requests_controller.rb
@@ -58,5 +58,4 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::DeletionRequestsController
       head :bad_request
     end
   end
-
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/deletion_requests_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/deletion_requests_controller.rb
@@ -24,7 +24,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::DeletionRequestsController
   #==================================================================
   # POST /deletion_request.json
   def create
-    @deletion_request = current_user.create_deletion_request!
+    @deletion_request = MnoEnterprise::DeletionRequest.create!(deletable: current_user)
     # TODO: deliver_later => need to use user#id and deletion_request#id
     MnoEnterprise::SystemNotificationMailer.deletion_request_instructions(current_user, @deletion_request).deliver_now
     render json: @deletion_request, status: :created
@@ -33,7 +33,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::DeletionRequestsController
   # PUT /deletion_request/1/resend.json
   def resend
     @deletion_request = current_user.current_deletion_request
-
     # Check that the user has a deletion_request in progress
     # and that the token provided (params[:id]) matches the
     # deletion_request token
@@ -59,4 +58,5 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::DeletionRequestsController
       head :bad_request
     end
   end
+
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboard_templates_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboard_templates_controller.rb
@@ -17,6 +17,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardTemplatesC
   # GET /mnoe/jpi/v1/impac/dashboard_templates
   def index
     @templates = MnoEnterprise::Dashboard.published_templates.includes(*DASHBOARD_DEPENDENCIES)
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboard_templates_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboard_templates_controller.rb
@@ -8,7 +8,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardTemplatesC
   # context where it is included rather than being executed in the module's context
   included do
     DASHBOARD_DEPENDENCIES = [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts']
-
     respond_to :json
   end
 
@@ -18,5 +17,6 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardTemplatesC
   # GET /mnoe/jpi/v1/impac/dashboard_templates
   def index
     @templates = MnoEnterprise::Dashboard.published_templates.includes(*DASHBOARD_DEPENDENCIES)
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
@@ -18,13 +18,13 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
   # GET /mnoe/jpi/v1/impac/dashboards
   def index
     dashboards
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
   end
 
   # GET /mnoe/jpi/v1/impac/dashboards/1
   #   -> GET /api/mnoe/v1/users/1/dashboards
   def show
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
     render_not_found('dashboard') unless dashboard(*DASHBOARD_DEPENDENCIES)
   end
 
@@ -37,7 +37,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     @dashboard = MnoEnterprise::Dashboard.create!(dashboard_create_params)
     MnoEnterprise::EventLogger.info('dashboard_create', current_user.id, 'Dashboard Creation', @dashboard)
     @dashboard = dashboard.load_required(*DASHBOARD_DEPENDENCIES)
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
     render 'show'
   end
 
@@ -49,7 +49,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     # TODO: enable authorization
     # authorize! :manage_dashboard, dashboard
     dashboard.update_attributes!(dashboard_update_params)
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
     # Reload Dashboard
     @dashboard = dashboard.load_required(DASHBOARD_DEPENDENCIES)
     render 'show'
@@ -76,7 +76,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     # Owner is the current user by default, can be overriden to something else (eg: current organization)
     @dashboard = template.copy!(current_user, dashboard_params[:name], dashboard_params[:organization_ids])
     @dashboard = @dashboard.load_required(DASHBOARD_DEPENDENCIES)
-    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
+    @organizations = MnoEnterprise::Organization.where('users.id': current_user.id)
     render 'show'
   end
 

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/dashboards_controller.rb
@@ -18,11 +18,13 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
   # GET /mnoe/jpi/v1/impac/dashboards
   def index
     dashboards
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
   end
 
   # GET /mnoe/jpi/v1/impac/dashboards/1
   #   -> GET /api/mnoe/v1/users/1/dashboards
   def show
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
     render_not_found('dashboard') unless dashboard(*DASHBOARD_DEPENDENCIES)
   end
 
@@ -35,6 +37,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     @dashboard = MnoEnterprise::Dashboard.create!(dashboard_create_params)
     MnoEnterprise::EventLogger.info('dashboard_create', current_user.id, 'Dashboard Creation', @dashboard)
     @dashboard = dashboard.load_required(*DASHBOARD_DEPENDENCIES)
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
     render 'show'
   end
 
@@ -46,7 +49,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     # TODO: enable authorization
     # authorize! :manage_dashboard, dashboard
     dashboard.update_attributes!(dashboard_update_params)
-
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
     # Reload Dashboard
     @dashboard = dashboard.load_required(DASHBOARD_DEPENDENCIES)
     render 'show'
@@ -73,6 +76,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::DashboardsControlle
     # Owner is the current user by default, can be overriden to something else (eg: current organization)
     @dashboard = template.copy!(current_user, dashboard_params[:name], dashboard_params[:organization_ids])
     @dashboard = @dashboard.load_required(DASHBOARD_DEPENDENCIES)
+    @organizations = MnoEnterprise::Organization.where('user.ids': current_user.id)
     render 'show'
   end
 

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
@@ -17,7 +17,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::WidgetsController
   #  -> GET /api/mnoe/v1/organizations/:id/widgets
   def index
     render_not_found('organization') unless parent_organization
-    @widgets = MnoEnterprise::Widget.find(organization_id: parent_organization_id)
+    @widgets = MnoEnterprise::Widget.find('organization.id': parent_organization.id)
   end
 
   # POST /mnoe/jpi/v1/impac/dashboards/:id/widgets

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/widgets_controller.rb
@@ -17,7 +17,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::WidgetsController
   #  -> GET /api/mnoe/v1/organizations/:id/widgets
   def index
     render_not_found('organization') unless parent_organization
-    @widgets = MnoEnterprise::Widget.find(organization_id: parent_organization.id)
+    @widgets = MnoEnterprise::Widget.find(organization_id: parent_organization_id)
   end
 
   # POST /mnoe/jpi/v1/impac/dashboards/:id/widgets

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
@@ -63,4 +63,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
   def app_instance_organization_id
     return params[:organization_id] if current_user && params[:organization_id].presence && orga_relation
   end
+
+  def orga_relation
+    MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, 'organization.id': params[:organization_id]).first
+  end
+
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
@@ -20,7 +20,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
     expires_in 0, public: true, must_revalidate: true
 
     # Memoize parent_organization_id if any
-    org_id = parent_organization_id
+    org_id = app_instance_organization_id
 
     # Compute cache key timestamp
     app_last_modified = app_relation(org_id).order(updated_at: :desc).select(:updated_at).first&.updated_at || Time.new(0)
@@ -45,7 +45,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
 
   # GET /mnoe/jpi/v1/marketplace/1(?organization_id=123)
   def show
-    @app = app_relation(parent_organization_id).find_one(params[:id])
+    @app = app_relation(app_instance_organization_id).find_one(params[:id])
   end
 
   #==================================================================
@@ -59,13 +59,8 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
     rel
   end
 
-  # Return the organization_id passed as query parameters if the current_user
-  # has access to it
-  def parent_organization_id
-    return nil unless current_user && params[:organization_id].presence
-    MnoEnterprise::Organization
-      .select(:id)
-      .where('id' => params[:organization_id], 'users.id' => current_user.id)
-      .first&.id
+  # Return the organization_id  passed as query parameters if the current_user has access to it
+  def app_instance_organization_id
+    return params[:organization_id] if current_user && params[:organization_id].presence && orga_relation
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/marketplace_controller.rb
@@ -61,11 +61,10 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::MarketplaceController
 
   # Return the organization_id  passed as query parameters if the current_user has access to it
   def app_instance_organization_id
-    return params[:organization_id] if current_user && params[:organization_id].presence && orga_relation
+    return params[:organization_id] if current_user && params[:organization_id].presence && orga_relation_id
   end
 
-  def orga_relation
-    MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, 'organization.id': params[:organization_id]).first
+  def orga_relation_id
+    MnoEnterprise::OrgaRelation.where('user.id': current_user.id, 'organization.id': params[:organization_id]).select(:id).first&.id
   end
-
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
@@ -18,7 +18,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::OrganizationsController
   #==================================================================
   # GET /mnoe/jpi/v1/organizations
   def index
-    @organizations ||= current_user.organizations
+    @organizations ||= MnoEnterprise::Organization.where('users.id': current_user.id)
   end
 
   # GET /mnoe/jpi/v1/organizations/1

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
@@ -11,8 +11,8 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::ProductsController
     query = MnoEnterprise::Product.apply_query_params(params).includes(DEPENDENCIES).where(active: true)
 
     # Ensure prices include organization-specific markups/discounts
-    if params[:organization_id] && parent_organization
-      query = query.with_params(_metadata: { organization_id: parent_organization.id })
+    if params[:organization_id] && orga_relation
+      query = query.with_params(_metadata: { organization_id: parent_organization_id })
     end
 
     @products = MnoEnterprise::Product.fetch_all(query)

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscription_events_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscription_events_controller.rb
@@ -8,14 +8,14 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionEventsControll
   #==================================================================
   # GET /mnoe/jpi/v1/organizations/1/subscriptions/xyz/subscription_events
   def index
-    authorize! :manage_app_instances, parent_organization
-    @subscription_events = fetch_subscription_events(parent_organization.id, params[:subscription_id])
+    authorize! :manage_app_instances, orga_relation
+    @subscription_events = fetch_subscription_events(parent_organization_id, params[:subscription_id])
   end
 
   # GET /mnoe/jpi/v1/organizations/1/subscriptions/xyz/subscription_events/id
   def show
-    authorize! :manage_app_instances, parent_organization
-    @subscription_event = fetch_subscription_event(parent_organization.id, params[:subscription_id], params[:id])
+    authorize! :manage_app_instances, orga_relation
+    @subscription_event = fetch_subscription_event(parent_organization_id, params[:subscription_id], params[:id])
   end
 
   protected

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscriptions_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscriptions_controller.rb
@@ -42,7 +42,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
   def update
     authorize! :manage_app_instances, orga_relation
 
-    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization_id, id: params[:id]).first
+    subscription = MnoEnterprise::Subscription.where('organization.id': parent_organization_id, id: params[:id]).first
     return render_not_found('subscription') unless subscription
     if params[:subscription][:product_pricing_id]
       subscription.relationships.product_pricing = MnoEnterprise::ProductPricing.new(id: params[:subscription][:product_pricing_id])
@@ -63,7 +63,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
   def cancel
     authorize! :manage_app_instances, orga_relation
 
-    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization_id, id: params[:id]).first
+    subscription = MnoEnterprise::Subscription.where('organization.id': parent_organization_id, id: params[:id]).first
     return render_not_found('subscription') unless subscription
     subscription.cancel!
 
@@ -84,11 +84,11 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
 
   def fetch_subscriptions(organization_id)
     query = MnoEnterprise::Subscription.with_params(_metadata: { organization_id: organization_id })
-    MnoEnterprise::Subscription.fetch_all(query.includes(*SUBSCRIPTION_INCLUDES).where(organization_id: organization_id))
+    MnoEnterprise::Subscription.fetch_all(query.includes(*SUBSCRIPTION_INCLUDES).where('organization.id': organization_id))
   end
 
   def fetch_subscription(organization_id, id)
     query = MnoEnterprise::Subscription.with_params(_metadata: { organization_id: organization_id })
-    query.includes(*SUBSCRIPTION_INCLUDES).where(organization_id: organization_id, id: id).first
+    query.includes(*SUBSCRIPTION_INCLUDES).where('organization.id': organization_id, id: id).first
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscriptions_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/subscriptions_controller.rb
@@ -8,22 +8,22 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
   #==================================================================
   # GET /mnoe/jpi/v1/organizations/1/subscriptions
   def index
-    authorize! :manage_app_instances, parent_organization
-    @subscriptions = fetch_subscriptions(parent_organization.id)
+    authorize! :manage_app_instances, orga_relation
+    @subscriptions = fetch_subscriptions(parent_organization_id)
   end
 
   # GET /mnoe/jpi/v1/organizations/1/subscriptions/id
   def show
-    authorize! :manage_app_instances, parent_organization
-    @subscription = fetch_subscription(parent_organization.id, params[:id])
+    authorize! :manage_app_instances, orga_relation
+    @subscription = fetch_subscription(parent_organization_id, params[:id])
   end
 
   # POST /mnoe/jpi/v1/organizations/1/subscriptions
   def create
-    authorize! :manage_app_instances, parent_organization
+    authorize! :manage_app_instances, orga_relation
 
     subscription = MnoEnterprise::Subscription.new(subscription_update_params)
-    subscription.relationships.organization = MnoEnterprise::Organization.new(id: parent_organization.id)
+    subscription.relationships.organization = MnoEnterprise::Organization.new(id: parent_organization_id)
     subscription.relationships.user = MnoEnterprise::User.new(id: current_user.id)
     if params[:subscription][:product_pricing_id]
       subscription.relationships.product_pricing = MnoEnterprise::ProductPricing.new(id: params[:subscription][:product_pricing_id])
@@ -34,15 +34,15 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
     subscription.save!
 
     MnoEnterprise::EventLogger.info('subscription_add', current_user.id, 'Subscription added', subscription)
-    @subscription = fetch_subscription(parent_organization.id, subscription.id)
+    @subscription = fetch_subscription(parent_organization_id, subscription.id)
     render :show
   end
 
   # PUT /mnoe/jpi/v1/organizations/1/subscriptions/abc
   def update
-    authorize! :manage_app_instances, parent_organization
+    authorize! :manage_app_instances, orga_relation
 
-    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization.id, id: params[:id]).first
+    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization_id, id: params[:id]).first
     return render_not_found('subscription') unless subscription
     if params[:subscription][:product_pricing_id]
       subscription.relationships.product_pricing = MnoEnterprise::ProductPricing.new(id: params[:subscription][:product_pricing_id])
@@ -55,20 +55,20 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::SubscriptionsController
     subscription.modify!(data: subscription.as_json_api)
 
     MnoEnterprise::EventLogger.info('subscription_update', current_user.id, 'Subscription updated', subscription)
-    @subscription = fetch_subscription(parent_organization.id, subscription.id)
+    @subscription = fetch_subscription(parent_organization_id, subscription.id)
     render :show
   end
 
   # POST /mnoe/jpi/v1/organizations/1/subscriptions/abc/cancel
   def cancel
-    authorize! :manage_app_instances, parent_organization
+    authorize! :manage_app_instances, orga_relation
 
-    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization.id, id: params[:id]).first
+    subscription = MnoEnterprise::Subscription.where(organization_id: parent_organization_id, id: params[:id]).first
     return render_not_found('subscription') unless subscription
     subscription.cancel!
 
     MnoEnterprise::EventLogger.info('subscription_update', current_user.id, 'Subscription cancelled', subscription)
-    @subscription = fetch_subscription(parent_organization.id, subscription.id)
+    @subscription = fetch_subscription(parent_organization_id, subscription.id)
     render :show
   end
 

--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -25,7 +25,7 @@ module MnoEnterprise::Concerns::Controllers::PagesController
   # TODO: Access + existence checks could be added in the future. This is not
   # mandatory as Mno Enterprise will do it anyway
   def launch
-    app_instance = MnoEnterprise::AppInstance.where(uid: params[:id]).first
+    app_instance = MnoEnterprise::AppInstance.where(uid: params[:id]).includes(:owner).first
     MnoEnterprise::EventLogger.info('app_launch', current_user.id, 'App launched', app_instance)
     redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
   end

--- a/api/lib/mno_enterprise/concerns/controllers/provision_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/provision_controller.rb
@@ -67,7 +67,8 @@ module MnoEnterprise::Concerns::Controllers::ProvisionController
 
     app_instances = []
     params[:apps].each do |product_name|
-      app_instance = @organization.provision_app_instance!(product_name)
+      app_instance = MnoEnterprise::AppInstance.provision!(product_name, parent_organization_id, 'Organization' )
+      app_instance = app_instance.load_required(:owner)
       app_instances << app_instance
       MnoEnterprise::EventLogger.info('app_add', current_user.id, 'App added', app_instance)
     end

--- a/api/lib/mno_enterprise/concerns/controllers/provision_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/provision_controller.rb
@@ -67,7 +67,7 @@ module MnoEnterprise::Concerns::Controllers::ProvisionController
 
     app_instances = []
     params[:apps].each do |product_name|
-      app_instance = MnoEnterprise::AppInstance.provision!(product_name, parent_organization_id, 'Organization' )
+      app_instance = MnoEnterprise::AppInstance.provision!(product_name, params[:organization_id], 'Organization' )
       app_instance = app_instance.load_required(:owner)
       app_instances << app_instance
       MnoEnterprise::EventLogger.info('app_add', current_user.id, 'App added', app_instance)

--- a/api/lib/mno_enterprise/concerns/mailers/system_notification_mailer.rb
+++ b/api/lib/mno_enterprise/concerns/mailers/system_notification_mailer.rb
@@ -228,7 +228,7 @@ module MnoEnterprise::Concerns::Mailers::SystemNotificationMailer
 
   def send_invoice(recipient_id, invoice_id)
     recipient = MnoEnterprise::User.select(:email, :name).find(recipient_id).first
-    invoice = MnoEnterprise::Invoice.find_one(invoice_id)
+    invoice = MnoEnterprise::Invoice.find_one(invoice_id, :organization)
     MnoEnterprise::MailClient.deliver(
       'invoice',
       default_sender,

--- a/api/lib/mno_enterprise/csv_importer.rb
+++ b/api/lib/mno_enterprise/csv_importer.rb
@@ -46,7 +46,7 @@ module MnoEnterprise
 
         if event_type == :added
           address = MnoEnterprise::Address.new(
-            city:         row['city'],
+            city: row['city'],
             country_code: row['country'],
             street: [row['address1'], row['address2']].reject(&:blank?).join(' '),
             state_code: row['state_province'],
@@ -72,10 +72,10 @@ module MnoEnterprise
         user.phone = row['phone']
 
         user.save
-        orga_relation = MnoEnterprise::OrgaRelation.where(user_id: user.id, organization_id: organization.id).first
+        orga_relation = MnoEnterprise::OrgaRelation.where('user.id': user.id, 'organization.id': organization.id).first
         # Add User as Super Admin to Organization if he is not already in it
         unless orga_relation
-          MnoEnterprise::OrgaRelation.create(user_id: user.id, organization_id: organization.id, role: 'Super Admin')
+          MnoEnterprise::OrgaRelation.create(user: user, organization: organization, role: 'Super Admin')
         end
       end
       report

--- a/api/spec/controllers/mno_enterprise/auth/omniauth_callback_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/auth/omniauth_callback_controller_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 module MnoEnterprise
   describe Auth::OmniauthCallbacksController, type: :controller do
     routes { MnoEnterprise::Engine.routes }
-    supported_providers = %i(linkedin google facebook)
+
+    ACTIVE_STATUSES = MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')
+
 
     describe 'provides callbacks for the providers' do
       before do
@@ -16,6 +18,58 @@ module MnoEnterprise
 
       it { expect(controller).to respond_to(:intuit) }
       it { expect(controller).to respond_to(:facebook) }
+    end
+
+    describe '.setup_apps' do
+      let(:app) { build(:app) }
+      let(:app_instance) { build(:app_instance, app: app, oauth_keys_valid: false) }
+      let(:user) { build(:user) }
+      let(:orga_relation) { build(:orga_relation, :super_admin) }
+      let(:organization) { build(:organization) }
+      let(:app_nids) { [app.nid] }
+      let(:options) { {} }
+      let(:get_app_instances_params) { { filter: { 'owner.id': organization.id, 'status.in': ACTIVE_STATUSES } } }
+
+      # setup_apps is a private method
+      subject { controller.send(:setup_apps, user, app_nids, options) }
+
+      before do
+        stub_api_v2(:get, '/organizations', [organization], [], { filter: { 'users.id': user.id }, fields: { organizations: 'id' } })
+        stub_api_v2(:get, '/orga_relations', [orga_relation], [], { filter: { 'user.id': user.id }, fields: { orga_relations: 'role' } })
+        stub_api_v2(:get, '/apps', [app], [], { filter: { 'nid.in': app.nid }, fields: { apps: 'id,nid' } })
+      end
+
+      context 'when the app_instance already exists' do
+        before { stub_api_v2(:get, '/app_instances', [app_instance], [:app], get_app_instances_params) }
+        it 'does not create a new app instance' do
+          expect(subject.length).to be(1)
+          expect(subject.first.id).to eq(app_instance.id)
+        end
+
+        describe 'when there is a oauth_keyset' do
+          let(:options) { { oauth_keyset: 'oauth_keyset' } }
+          let!(:stub) { stub_api_v2(:patch, "/app_instances/#{app_instance.id}", app_instance) }
+          it do
+            subject
+            expect(stub).to have_been_requested
+          end
+        end
+
+      end
+      context 'when there is no previous app instance' do
+        let(:provisioned_app_instance) { build(:app_instance) }
+        before do
+          stub_audit_events
+          stub_api_v2(:get, '/app_instances', [], [:app], get_app_instances_params)
+          stub_api_v2(:get, '/app_instances/' + provisioned_app_instance.id, provisioned_app_instance, [:owner])
+        end
+        let!(:stub) { stub_api_v2(:post, '/app_instances/provision', provisioned_app_instance) }
+        it 'provisions the app_instance' do
+          expect(subject.length).to be(1)
+          expect(subject.first.id).to eq(provisioned_app_instance.id)
+          expect(stub).to have_been_requested
+        end
+      end
     end
   end
 end

--- a/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/impersonate_controller_spec.rb
@@ -8,12 +8,11 @@ module MnoEnterprise
     let(:user) { build(:user, :admin) }
     let(:user2) { build(:user) }
     before do
-      stub_user(user)
-      stub_api_v2(:get, "/users/#{user2.id}", user2, %i(deletion_requests organizations orga_relations dashboards teams user_access_requests sub_tenant))
-
+      stub_api_v2(:get, "/users/#{user.id}", user)
+      stub_api_v2(:get, "/users/#{user.id}", user, %i(user_access_requests))
+      stub_api_v2(:get, "/users/#{user2.id}", user2, %i(user_access_requests))
       stub_api_v2(:patch, "/users/#{user.id}")
       stub_api_v2(:patch, "/users/#{user2.id}")
-
     end
     before { stub_audit_events }
 
@@ -37,7 +36,7 @@ module MnoEnterprise
         end
 
         context 'when the user does not exist' do
-          before { stub_api_v2(:get, '/users/crappyId', [], %i(deletion_requests organizations orga_relations dashboards teams user_access_requests sub_tenant)) }
+          before { stub_api_v2(:get, '/users/crappyId', [], %i(user_access_requests)) }
           subject { get :create, user_id: 'crappyId', dhbRefId: 10 }
           it do
             is_expected.to redirect_to('/admin/#!?flash=%7B%22msg%22%3A%22User+does+not+exist%22%2C%22type%22%3A%22error%22%7D')

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_answers_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_answers_controller_spec.rb
@@ -11,7 +11,7 @@ module MnoEnterprise
     #===============================================
     # Assignments
     #===============================================
-    let(:user) { build(:user, :admin, orga_relations: [orga_relation]) }
+    let(:user) { build(:user, :admin) }
     let!(:orga_relation) { build(:orga_relation) }
     let!(:current_user_stub) { stub_user(user) }
     let(:question) { build(:question) }
@@ -31,6 +31,7 @@ module MnoEnterprise
       before do
         stub_api_v2(:get, "/questions/#{question.id}", question)
         stub_api_v2(:post, '/answers', answer)
+        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {'user.id': user.id}, page: one_page})
       end
 
       subject { post :create, app_answer: params, question_id: question.id }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_comments_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_comments_controller_spec.rb
@@ -11,7 +11,7 @@ module MnoEnterprise
     #===============================================
     # Assignments
     #===============================================
-    let(:user) { build(:user, :admin, orga_relations: [orga_relation]) }
+    let(:user) { build(:user, :admin) }
     let!(:orga_relation) { build(:orga_relation) }
     let!(:current_user_stub) { stub_user(user) }
     let(:feedback) { build(:feedback) }
@@ -31,6 +31,7 @@ module MnoEnterprise
       before do
         stub_api_v2(:get, "/feedbacks/#{feedback.id}", feedback)
         stub_api_v2(:post, '/comments', comment)
+        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {'user.id': user.id}, page: one_page})
       end
 
       subject { post :create, app_comment: params, feedback_id: feedback.id }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_instances_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_instances_controller_spec.rb
@@ -10,7 +10,8 @@ module MnoEnterprise
     before { request.env['HTTP_ACCEPT'] = 'application/json' }
     before { stub_audit_events }
 
-    let(:user) { build(:user, :admin, :with_organizations) }
+    let(:user) { build(:user, :admin) }
+    let(:organization) { build(:organization) }
     let!(:current_user_stub) { stub_user(user) }
 
     before do
@@ -19,9 +20,9 @@ module MnoEnterprise
 
     describe 'DELETE #destroy' do
       # Stub AppInstance
-      let(:app_instance) { build(:app_instance) }
+      let(:app_instance) { build(:app_instance, owner: organization) }
 
-      before { stub_api_v2(:get, "/app_instances/#{app_instance.id}", app_instance) }
+      before { stub_api_v2(:get, "/app_instances/#{app_instance.id}", app_instance, [:owner]) }
       let!(:stub) { stub_api_v2(:delete, "/app_instances/#{app_instance.id}/terminate") }
 
       subject { delete :destroy, id: app_instance.id }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller_spec.rb
@@ -71,7 +71,7 @@ module MnoEnterprise
     before do
       stub_user(user)
       sign_in user
-      stub_api_v2(:get, '/organizations', [organization], [], filter: { 'user.ids': user.id })
+      stub_api_v2(:get, '/organizations', [organization], [], filter: { 'users.id': user.id })
       stub_audit_events
     end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/invites_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/invites_controller_spec.rb
@@ -11,13 +11,13 @@ module MnoEnterprise
     # Assignments
     #===============================================
     # Stub user and user call
-    let(:user) { build(:user, admin_role: 'admin') }
+    let(:user) { build(:user, :admin) }
     let!(:current_user_stub) { stub_user(user) }
     before do
       sign_in user
     end
 
-    let(:organization) { build(:organization, orga_relations: []) }
+    let(:organization) { build(:organization) }
     let(:invitee) { build(:user) }
     let(:invite) { build(:orga_invite, user: invitee, organization: organization, status: 'staged') }
 
@@ -29,15 +29,9 @@ module MnoEnterprise
 
     # API stubs
     before do
-      allow(MnoEnterprise::User).to receive(:find) do |user_id|
-        case user_id.to_i
-        when user.id then user
-        when invitee.id then invitee
-        end
-      end
       stub_api_v2(:get, "/users/#{invitee.id}", invitee)
       stub_api_v2(:get, "/organizations/#{organization.id}", organization, [:orga_relations])
-      stub_api_v2(:get, '/orga_invites', [invite], [:user, :organization, :team, :referrer], {filter: {organization_id: organization.id, user_id: invitee.id, 'status.in': 'staged,pending'}, page:{number:1, size: 1}})
+      stub_api_v2(:get, '/orga_invites', [invite], [:user, :organization, :team, :referrer], { filter: { organization_id: organization.id, user_id: invitee.id, 'status.in': 'staged,pending' }, page: { number: 1, size: 1 } })
       #reload
       stub_api_v2(:get, "/orga_invites/#{invite.id}", invite, [:user])
       stub_api_v2(:patch, "/orga_invites/#{invite.id}", invite)
@@ -58,7 +52,7 @@ module MnoEnterprise
         end
       end
 
-      context 'new user'  do
+      context 'new user' do
         let(:invitee) { build(:user, confirmed_at: nil) }
 
         it 'sends the confirmation instructions' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -232,10 +232,9 @@ module MnoEnterprise
             stub_api_v2(:post, '/users', user2),
             stub_api_v2(:patch, "/users/#{user1.id}", user1),
 
-            stub_api_v2(:get, '/orga_relations', [], [], { filter: { user_id: user1.id, organization_id: organization1.id }, page: { number: 1, size: 1 } }),
-            stub_api_v2(:get, '/orga_relations', [orga_relation1], [], { filter: { user_id: user2.id, organization_id: organization2.id }, page: { number: 1, size: 1 } }),
-
-            stub_api_v2(:post, '/orga_relations', orga_relation2)
+            stub_orga_relation(user1, organization1, nil),
+            stub_orga_relation(user2, organization2, orga_relation2),
+            stub_api_v2(:post, '/orga_relations', orga_relation1)
           ]
         }
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -110,10 +110,10 @@ module MnoEnterprise
 
       describe 'app provisioning' do
         let(:params) { attributes_for(:organization).merge(app_nids: ['xero', app_instance.app.nid]) }
-
-        before { expect_any_instance_of(Organization).to receive(:provision_app_instance!) }
+        let!(:provisionning_stub) { stub_api_v2(:post, '/app_instances/provision')}
         before { subject }
         it { expect(data['organization']['id']).to eq(organization.id) }
+        it { expect(provisionning_stub).to have_been_requested }
       end
     end
 
@@ -130,7 +130,7 @@ module MnoEnterprise
         let(:orga_invite) { build(:orga_invite) }
 
         before { allow(orga_invite).to receive(:user).and_return(invited_user) }
-        before { stub_api_v2(:get, '/users', invited_user, [:orga_relations], { filter: { email: params[:email] }, page: { number: 1, size: 1 } }) }
+        before { stub_api_v2(:get, '/users', invited_user, [:orga_relations], { filter: { email: params[:email] }, page: one_page }) }
         before { stub_api_v2(:get, "/orga_invites/#{orga_invite.id}", orga_invite, [:user]) }
         before { expect(MnoEnterprise::OrgaInvite).to receive(:create).and_return(orga_invite) }
         before { subject }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/users_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/users_controller_spec.rb
@@ -14,6 +14,13 @@ module MnoEnterprise
     let(:current_user) { build(:user, :admin) }
     let!(:current_user_stub) { stub_user(current_user) }
 
+    let(:select_fields) do
+      {
+        users: Jpi::V1::Admin::UsersController::INCLUDED_FIELDS.join(',')
+      }
+    end
+
+
     # Stub user and user call
     let(:user) { build(:user) }
 
@@ -27,7 +34,7 @@ module MnoEnterprise
 
       let(:data) { JSON.parse(response.body) }
 
-      before { stub_api_v2(:get, "/users", [user], [:user_access_requests, :sub_tenant], { _metadata: { act_as_manager: current_user.id } }) }
+      before { stub_api_v2(:get, "/users", [user], [:user_access_requests, :sub_tenant], {fields: select_fields, _metadata: { act_as_manager: current_user.id } }) }
       before { subject }
 
       it { expect(data['users'].first['id']).to eq(user.id) }
@@ -39,7 +46,7 @@ module MnoEnterprise
       let(:data) { JSON.parse(response.body) }
       let(:included) { [:orga_relations, :organizations, :user_access_requests, :sub_tenant] }
 
-      before { stub_api_v2(:get, "/users/#{user.id}", user, included, { _metadata: { act_as_manager: current_user.id } }) }
+      before { stub_api_v2(:get, "/users/#{user.id}", user, included, {fields: select_fields, _metadata: { act_as_manager: current_user.id } }) }
       before { subject }
 
       it { expect(data['user']['id']).to eq(user.id) }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_answers_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_answers_controller_spec.rb
@@ -51,7 +51,7 @@ module MnoEnterprise
       let(:params) { {organization_id: organization.id, description: 'A Review', foo: 'bar', question_id: 'qid'} }
 
       before do
-        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {organization_id: organization.id, user_id: user.id}, page: {number: 1, size: 1}})
+        stub_orga_relation(user, organization, orga_relation)
         stub_api_v2(:post, '/answers', answer1)
       end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_comments_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_comments_controller_spec.rb
@@ -50,7 +50,7 @@ module MnoEnterprise
       let(:params) { {organization_id: organization.id, description: 'A Review', foo: 'bar', feedback_id: 'fid'} }
 
       before do
-        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {organization_id: organization.id, user_id: user.id}, page: {number: 1, size: 1}})
+        stub_orga_relation(user, organization, orga_relation)
         stub_api_v2(:post, '/comments', comment1)
       end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_feedbacks_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_feedbacks_controller_spec.rb
@@ -56,7 +56,7 @@ module MnoEnterprise
       let(:params) { {organization_id: organization.id, description: 'A Review', rating: 5} }
       let(:feedback) { build(:feedback, id: feedback_id, comments: []) }
       before do
-        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {organization_id: organization.id, user_id: user.id}, page: {number: 1, size: 1}})
+        stub_orga_relation(user, organization, orga_relation)
         stub_api_v2(:post, '/feedbacks', feedback)
       end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_instances_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_instances_controller_spec.rb
@@ -18,7 +18,7 @@ module MnoEnterprise
     let(:orga_relation) { build(:orga_relation) }
     let!(:current_user_stub) { stub_user(user) }
 
-    before { stub_api_v2(:get, '/orga_relations', orga_relation, [], { filter: { 'user.id': user.id, 'organization.id': organization.id }, page: { number: 1, size: 1 } }) }
+    before { stub_orga_relation(user, organization, orga_relation) }
 
     describe 'GET #index' do
       let(:app_instance) { build(:app_instance, status: 'running', under_free_trial: false) }
@@ -54,6 +54,7 @@ module MnoEnterprise
       let!(:stub) { stub_api_v2(:post, '/app_instances/provision', app_instance) }
       before do
         sign_in user
+        stub_api_v2(:get, "/app_instances/#{app_instance.id}", app_instance, [:owner])
       end
 
       it do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_questions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_questions_controller_spec.rb
@@ -56,7 +56,7 @@ module MnoEnterprise
       let(:params) { {organization_id: organization.id, description: 'A Review', foo: 'bar'} }
       let(:question) { build(:question, id: question_id, answers: []) }
       before do
-        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {organization_id: organization.id, user_id: user.id}, page: {number: 1, size: 1}})
+        stub_orga_relation(user, organization, orga_relation)
         stub_api_v2(:post, '/questions', question)
       end
       subject { post :create, id: app.id, app_question: params }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_reviews_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_reviews_controller_spec.rb
@@ -52,7 +52,7 @@ module MnoEnterprise
     describe 'POST #create', focus: true do
       let(:params) { {organization_id: organization.id, description: 'A Review', rating: 5} }
       before do
-        stub_api_v2(:get, '/orga_relations', [orga_relation], [], {filter: {organization_id: organization.id, user_id: user.id}, page: {number: 1, size: 1}})
+        stub_orga_relation(user, organization, orga_relation)
         stub_api_v2(:post, '/reviews', review)
       end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/audit_events_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/audit_events_controller_spec.rb
@@ -17,18 +17,15 @@ module MnoEnterprise
 
     # Stub user and mnoe API calls
     let(:user) { build(:user) }
-    let!(:organization) {
-      o = build(:organization, orga_relations: [])
-      o.orga_relations << build(:orga_relation, user_id: user.id, organization_id: o.id, role: "Super Admin")
-      o
-    }
+    let(:organization) { build(:organization) }
+    let(:orga_relation) { build(:orga_relation) }
     let(:audit_event) { build(:audit_event) }
 
     let!(:current_user_stub) { stub_user(user) }
-    before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations users)) }
     before { stub_api_v2(:get, "/organizations/#{organization.id}", organization) }
     before do
-      stub_api_v2(:get, '/audit_events', [audit_event], [], {filter: {organization_id: organization.id}})
+      stub_orga_relation(user, organization, orga_relation)
+      stub_api_v2(:get, '/audit_events', [audit_event], [], { filter: { organization_id: organization.id } })
       sign_in user
     end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboard_templates_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboard_templates_controller_spec.rb
@@ -10,8 +10,8 @@ module MnoEnterprise
 
     let(:dashboard_dependencies) { %w(widgets widgets.kpis kpis kpis.alerts) }
 
-    let(:user) { build(:user, :with_organizations) }
-    let(:org) { user.organizations.first || build(:organization, users: [user]) }
+    let(:user) { build(:user) }
+    let(:organization) { build(:organization)}
     let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
 
     let(:widget) { build(:impac_widget, owner: user) }
@@ -20,7 +20,7 @@ module MnoEnterprise
     let(:template) do
       build(:impac_dashboard,
             dashboard_type: 'template',
-            organization_ids: [org.uid],
+            organization_ids: [organization.uid],
             currency: 'EUR',
             settings: metadata,
             widgets: [widget],
@@ -59,7 +59,7 @@ module MnoEnterprise
         "full_name" => template.full_name,
         "currency" => 'EUR',
         "metadata" => metadata.deep_stringify_keys,
-        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name}],
+        "data_sources" => [{ "id" => organization.id, "uid" => organization.uid, "label" => organization.name}],
         "kpis" => [hash_for_kpi(d_kpi)],
         "widgets" => [hash_for_widget]
       }
@@ -72,7 +72,8 @@ module MnoEnterprise
       subject { get :index }
 
       before do
-        stub_api_v2(:get, "/dashboards", [template], dashboard_dependencies, filter: {dashboard_type: 'template', published: true})
+        stub_api_v2(:get, '/organizations', [organization], [], filter: { 'user.ids': user.id})
+        stub_api_v2(:get, '/dashboards', [template], dashboard_dependencies, filter: { dashboard_type: 'template', published: true})
       end
 
       it_behaves_like "jpi v1 protected action"

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboard_templates_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboard_templates_controller_spec.rb
@@ -72,7 +72,7 @@ module MnoEnterprise
       subject { get :index }
 
       before do
-        stub_api_v2(:get, '/organizations', [organization], [], filter: { 'user.ids': user.id})
+        stub_api_v2(:get, '/organizations', [organization], [], filter: { 'users.id': user.id})
         stub_api_v2(:get, '/dashboards', [template], dashboard_dependencies, filter: { dashboard_type: 'template', published: true})
       end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
@@ -11,8 +11,8 @@ module MnoEnterprise
     let(:dashboard_dependencies) { [:widgets, :'widgets.kpis', :kpis, :'kpis.alerts', :'kpis.alerts.recipients'] }
 
     # Stub user and user call
-    let(:org) { build(:organization, users: [], orga_relations: []) }
-    let!(:user) { build(:user, organizations: [org]) }
+    let(:organization) { build(:organization) }
+    let!(:user) { build(:user) }
     let!(:current_user_stub) { stub_user(user) }
 
     let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
@@ -25,7 +25,7 @@ module MnoEnterprise
     let(:dashboard) do
       build(:impac_dashboard,
             dashboard_type: 'dashboard',
-            organization_ids: [org.uid],
+            organization_ids: [organization.uid],
             currency: 'EUR',
             settings: metadata,
             widgets: [widget],
@@ -76,7 +76,7 @@ module MnoEnterprise
         "full_name" => dashboard.full_name,
         "currency" => 'EUR',
         "metadata" => metadata.deep_stringify_keys,
-        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name }],
+        "data_sources" => [{ "id" => organization.id, "uid" => organization.uid, "label" => organization.name }],
         "kpis" => [hash_for_kpi(d_kpi)],
         "widgets" => [hash_for_widget]
       }
@@ -85,6 +85,7 @@ module MnoEnterprise
     before do
       sign_in user
       stub_audit_events
+      stub_api_v2(:get, '/organizations', [organization], [], filter: { 'user.ids': user.id})
     end
 
     describe 'GET #index' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
@@ -85,7 +85,7 @@ module MnoEnterprise
     before do
       sign_in user
       stub_audit_events
-      stub_api_v2(:get, '/organizations', [organization], [], filter: { 'user.ids': user.id})
+      stub_api_v2(:get, '/organizations', [organization], [], filter: { 'users.id': user.id})
     end
 
     describe 'GET #index' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/widgets_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/widgets_controller_spec.rb
@@ -27,7 +27,7 @@ module MnoEnterprise
       subject { get :index, organization_id: organization.uid }
 
       before { stub_api_v2(:get, '/organizations', [organization], [], { filter: { uid: organization.uid } }) }
-      before { stub_api_v2(:get, '/widgets', [widget], [], { filter: { organization_id: organization.id } }) }
+      before { stub_api_v2(:get, '/widgets', [widget], [], { filter: { 'organization.id': organization.id } }) }
       it 'returns the widgets' do
         subject
         expect(JSON.parse(response.body)).to eq({ 'widgets' => [

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/widgets_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/widgets_controller_spec.rb
@@ -13,27 +13,26 @@ module MnoEnterprise
 
     # Stub user and user call
     let!(:user) { build(:user) }
+    let!(:organization) { build(:organization) }
+    let!(:orga_relation) { build(:orga_relation) }
     let!(:current_user_stub) { stub_user(user) }
 
     before { sign_in user }
+    before { stub_orga_relation(user, organization, orga_relation, 'uid') }
 
     describe 'GET index' do
-      let!(:organization) {
-        o = build(:organization, orga_relations: [])
-        o.orga_relations << build(:orga_relation, user_id: user.id, organization_id: o.id, role: 'Super Admin')
-        o
-      }
-      let!(:widget) { build(:impac_widget, settings: {organization_ids: [organization.uid]}) }
+
+      let!(:widget) { build(:impac_widget, settings: { organization_ids: [organization.uid] }) }
 
       subject { get :index, organization_id: organization.uid }
 
-      before { stub_api_v2(:get, '/organizations', [organization], %i(orga_relations users), {filter: {uid: organization.uid}}) }
-      before { stub_api_v2(:get, '/widgets', [widget], [], {filter: {organization_id: organization.id}}) }
+      before { stub_api_v2(:get, '/organizations', [organization], [], { filter: { uid: organization.uid } }) }
+      before { stub_api_v2(:get, '/widgets', [widget], [], { filter: { organization_id: organization.id } }) }
       it 'returns the widgets' do
         subject
-        expect(JSON.parse(response.body)).to eq({'widgets' => [
-          {'id' => widget.id, 'endpoint' => widget.endpoint, 'settings' => {'organization_ids' => [organization.uid]}}
-        ]})
+        expect(JSON.parse(response.body)).to eq({ 'widgets' => [
+          { 'id' => widget.id, 'endpoint' => widget.endpoint, 'settings' => { 'organization_ids' => [organization.uid] } }
+        ] })
       end
     end
   end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
@@ -133,7 +133,8 @@ module MnoEnterprise
         before do
           sign_in(user)
           stub_api_v2(:get, "/organizations", [organization], [], { fields: { organizations: 'id' }, filter: { id: organization.id, 'users.id' => user.id }, page: one_page })
-          stub_orga_relation(user, organization, orga_relation)
+          stub_api_v2(:get, '/orga_relations', [orga_relation], [], { fields: { orga_relations: 'id' }, filter: { 'user.id': user.id, 'organization.id': organization.id }, page: one_page })
+
           stub_api_v2(:get, '/apps', [app], DEPENDENCIES, { _metadata: { organization_id: organization.id }, filter: { active: true } })
           stub_api_v2(:get, '/apps', [app], [],
                       {

--- a/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/marketplace_controller_spec.rb
@@ -127,12 +127,14 @@ module MnoEnterprise
         subject { get :index, organization_id: organization.id }
         let!(:organization) { build(:organization) }
         let!(:user) { build(:user) }
+        let(:orga_relation) { build(:orga_relation) }
         let!(:current_user_stub) { stub_user(user) }
 
-        before { sign_in user }
-        before { stub_api_v2(:get, "/organizations", [organization], [], { fields: { organizations: 'id' }, filter: { id: organization.id, 'users.id' => user.id }, page: { number: 1, size: 1 } }) }
-        before { stub_api_v2(:get, '/apps', [app], DEPENDENCIES, { _metadata: { organization_id: organization.id }, filter: { active: true } }) }
         before do
+          sign_in(user)
+          stub_api_v2(:get, "/organizations", [organization], [], { fields: { organizations: 'id' }, filter: { id: organization.id, 'users.id' => user.id }, page: one_page })
+          stub_orga_relation(user, organization, orga_relation)
+          stub_api_v2(:get, '/apps', [app], DEPENDENCIES, { _metadata: { organization_id: organization.id }, filter: { active: true } })
           stub_api_v2(:get, '/apps', [app], [],
                       {
                         _metadata: { organization_id: organization.id },

--- a/api/spec/controllers/mno_enterprise/jpi/v1/products_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/products_controller_spec.rb
@@ -8,24 +8,23 @@ module MnoEnterprise
     before { request.env['HTTP_ACCEPT'] = 'application/json' }
 
     before(:all) do
-      Settings.merge!(dashboard: {marketplace: {local_products: true}})
+      Settings.merge!(dashboard: { marketplace: { local_products: true } })
       Rails.application.reload_routes!
     end
 
     # Stub user and user call
     let!(:user) { build(:user) }
+    let(:organization) { build(:organization) }
     let!(:current_user_stub) { stub_user(user) }
+    before do
+      stub_orga_relation(user, organization, build(:orga_relation))
+    end
 
     describe 'GET #index' do
       subject { get :index, params }
 
       let(:params) { {} }
       let(:product) { build(:product) }
-      let(:organization) {
-        o = build(:organization, orga_relations: [])
-        o.orga_relations << build(:orga_relation, user_id: user.id, organization_id: o.id, role: 'Super Admin')
-        o
-      }
 
       before { sign_in user }
 
@@ -40,7 +39,7 @@ module MnoEnterprise
         before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations users)) }
         before do
           stub_api_v2(:get, "/products", [product],
-            [:'values.field', :assets, :categories, :product_pricings, :product_contracts], { filter: { active: true }, _metadata: { organization_id: organization.id } })
+                      [:'values.field', :assets, :categories, :product_pricings, :product_contracts], { filter: { active: true }, _metadata: { organization_id: organization.id } })
         end
 
         it_behaves_like 'jpi v1 protected action'

--- a/api/spec/controllers/mno_enterprise/jpi/v1/subscription_events_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/subscription_events_controller_spec.rb
@@ -21,9 +21,11 @@ module MnoEnterprise
     let!(:current_user_stub) { stub_user(user) }
 
     # Stub organization and association
-    let!(:organization) { build(:organization, orga_relations: []) }
-    let!(:orga_relation) { organization.orga_relations << build(:orga_relation, user_id: user.id, organization_id: organization.id, role: 'Super Admin') }
-    let!(:organization_stub) { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations users)) }
+    let!(:organization) { build(:organization) }
+    let!(:orga_relation) { build(:orga_relation, role: 'Super Admin') }
+    before do
+      stub_orga_relation(user, organization, orga_relation)
+    end
 
     describe 'GET #index' do
       let(:subscription) { build(:subscription) }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/subscriptions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/subscriptions_controller_spec.rb
@@ -21,10 +21,11 @@ module MnoEnterprise
     let!(:current_user_stub) { stub_user(user) }
 
     # Stub organization and association
-    let!(:organization) { build(:organization, orga_relations: []) }
-    let!(:orga_relation) { organization.orga_relations << build(:orga_relation, user_id: user.id, organization_id: organization.id, role: 'Super Admin') }
-    let!(:organization_stub) { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations users)) }
-
+    let!(:organization) { build(:organization) }
+    let!(:orga_relation) { build(:orga_relation, role: 'Super Admin') }
+    before do
+      stub_orga_relation(user, organization, orga_relation)
+    end
     # Stub license_assignments association
     before { allow_any_instance_of(MnoEnterprise::Subscription).to receive(:license_assignments).and_return([]) }
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/subscriptions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/subscriptions_controller_spec.rb
@@ -32,7 +32,7 @@ module MnoEnterprise
     describe 'GET #index' do
       let(:subscription) { build(:subscription) }
 
-      before { stub_api_v2(:get, "/subscriptions", [subscription], [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {organization_id: organization.id}, '_metadata[organization_id]' => organization.id}) }
+      before { stub_api_v2(:get, "/subscriptions", [subscription], [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {'organization.id': organization.id}, '_metadata[organization_id]' => organization.id}) }
       before { sign_in user }
 
       subject { get :index, organization_id: organization.id }
@@ -43,7 +43,7 @@ module MnoEnterprise
     describe 'GET #show' do
       let(:subscription) { build(:subscription) }
 
-      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
       before { sign_in user }
 
       subject { get :show, organization_id: organization.id, id: subscription.id }
@@ -58,7 +58,7 @@ module MnoEnterprise
 
       before { stub_audit_events }
       before { stub_api_v2(:post, "/subscriptions", subscription, [], {}) }
-      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
       before { sign_in user }
 
       subject { post :create, organization_id: organization.id, subscription: {custom_data: {foo: :bar}.to_json, product_pricing_id: product_pricing.id} }
@@ -91,8 +91,8 @@ module MnoEnterprise
 
       before { stub_audit_events }
       before { stub_api_v2(:post, "/subscriptions/#{subscription.id}/modify", subscription, [], {}) }
-      before { stub_api_v2(:get, "/subscriptions", subscription, [], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1}) }
-      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
       before { sign_in user }
 
       subject { put :update, organization_id: organization.id, id: subscription.id, subscription: {custom_data: {foo: :bar}.to_json, product_pricing_id: product_pricing.id} }
@@ -124,8 +124,8 @@ module MnoEnterprise
 
       before { stub_audit_events }
       before { stub_api_v2(:post, "/subscriptions/#{subscription.id}/cancel", subscription, [], {}) }
-      before { stub_api_v2(:get, "/subscriptions", subscription, [], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1}) }
-      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {organization_id: organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1}) }
+      before { stub_api_v2(:get, "/subscriptions", subscription, [:'product_pricing.product', :product_contract, :organization, :user, :'license_assignments.user', :'product_instance.product'], {filter: {'organization.id': organization.id, id: subscription.id}, 'page[number]' => 1, 'page[size]' => 1, '_metadata[organization_id]' => organization.id}) }
       before { sign_in user }
 
       subject { post :cancel, organization_id: organization.id, id: subscription.id }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/teams_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/teams_controller_spec.rb
@@ -58,18 +58,19 @@ module MnoEnterprise
     # Specs
     #===============================================
     describe 'PUT #add_users' do
-
-      let!(:current_user_stub) { stub_user(user) }
-
-      before { stub_api_v2(:get, "/apps", [app]) }
-      before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations)) }
-      before { stub_api_v2(:get, "/teams/#{team.id}", team, %i(organization)) }
-      before { stub_api_v2(:patch, "/teams/#{team.id}") }
-      before { stub_audit_events }
       subject { put :add_users, id: team.id, team: {users: [{id: user.id}]} }
+      before do
+        stub_user(user)
+        stub_orga_relation(user, organization, build(:orga_relation))
+        stub_api_v2(:get, "/apps", [app])
+        stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(orga_relations))
+        stub_api_v2(:get, "/teams/#{team.id}", team, %i(organization))
+        stub_api_v2(:patch, "/teams/#{team.id}")
+        # team reload
+        stub_api_v2(:get, "/teams/#{team.id}", team, %i(organization users app_instances))
+        stub_audit_events
+      end
 
-      # team reload
-      before { stub_api_v2(:get, "/teams/#{team.id}", team, %i(organization users app_instances)) }
       context 'success' do
         before { subject }
 

--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -16,7 +16,7 @@ module MnoEnterprise
 
     before do
       stub_user(user)
-      stub_api_v2(:get, '/app_instances', [app_instance], [], {filter:{uid: app_instance.uid}, page:{number: 1, size: 1}})
+      stub_api_v2(:get, '/app_instances', [app_instance], [:owner], { filter: { uid: app_instance.uid }, page: one_page })
     end
 
     describe 'GET #launch' do
@@ -28,7 +28,7 @@ module MnoEnterprise
 
       it 'redirect to the mno enterprise launch page with a web token' do
         subject
-        expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({user_id: user.uid})))
+        expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({ user_id: user.uid })))
       end
     end
 
@@ -41,7 +41,7 @@ module MnoEnterprise
 
       it 'redirects to the mno enterprise launch page with a web token and extra params' do
         subject
-        expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific_parameters_value'))
+        expect(response).to redirect_to(MnoEnterprise.router.launch_url(app_instance.uid, wtk: MnoEnterprise.jwt({ user_id: user.uid }), specific_parameters: 'specific_parameters_value'))
       end
     end
 

--- a/api/spec/controllers/mno_enterprise/provision_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/provision_controller_spec.rb
@@ -109,6 +109,7 @@ module MnoEnterprise
       subject { post :create, params }
       before do
         stub_api_v2(:post, "/app_instances/provision", app_instance)
+        stub_api_v2(:get, "/app_instances/#{app_instance.id}", app_instance, [:owner])
       end
 
       describe 'guest' do

--- a/api/spec/mailer/mno_enterprise/system_notification_mailer_spec.rb
+++ b/api/spec/mailer/mno_enterprise/system_notification_mailer_spec.rb
@@ -9,7 +9,7 @@ module MnoEnterprise
     end
     let(:routes) { MnoEnterprise::Engine.routes.url_helpers }
     let(:user) { build(:user) }
-    let(:token) { "1sd5f323S1D5AS" }
+    let(:token) { '1sd5f323S1D5AS' }
     let(:deletion_request) { build(:deletion_request) }
 
     # Commonly used mandrill variables
@@ -183,7 +183,7 @@ module MnoEnterprise
       before do
         Timecop.freeze
         stub_api_v2(:get, "/users/#{user.id}", user, [], {fields: {users: 'email,name'}})
-        stub_api_v2(:get, "/invoices/#{invoice.id}", invoice)
+        stub_api_v2(:get, "/invoices/#{invoice.id}", invoice, [:organization])
       end
       after { Timecop.return }
       let(:invoice) { build(:invoice) }

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -173,6 +173,19 @@ module MnoEnterprise
       end
     end
 
+    def render_not_found(resource, id = params[:id])
+      render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
+    end
+
+    def render_bad_request(attempted_action, issue)
+      issue = issue.full_messages if issue.respond_to?(:full_messages)
+      render json: { errors: { message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params } }, status: :bad_request
+    end
+
+    def render_forbidden_request(attempted_action)
+      render json: { errors: { message: "Error while trying to #{attempted_action}: you do not have permission", code: 403 } }, status: :forbidden
+    end
+
     private
 
     # Append params to the fragment part of an existing url String

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -138,6 +138,41 @@ module MnoEnterprise
       MnoEnterprise.router.after_sign_out_url || super
     end
 
+    #============================================
+    # Helper methods
+    #============================================
+
+    # test if the provided argument is a id or an uid
+    # @param [Object] id or uid
+    def is_id?(string)
+      string.to_i.to_s == string
+    end
+
+    def parent_organization_id
+      id_or_uid = params[:organization_id]
+      if is_id?(id_or_uid)
+        id_or_uid
+      else
+        parent_organization.id
+      end
+    end
+
+    def parent_organization
+      @parent_organization ||= begin
+        id_or_uid = params[:organization_id]
+        query = is_id?(id_or_uid) ? id_or_uid : { uid: id_or_uid }
+        MnoEnterprise::Organization.find(query).first
+      end
+    end
+
+    def orga_relation
+      @orga_relation ||= begin
+        id_or_uid = params[:organization_id]
+        organization_field = is_id?(id_or_uid) ? 'id' : 'uid'
+        MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, "organization.#{organization_field}" => id_or_uid).first
+      end
+    end
+
     private
 
     # Append params to the fragment part of an existing url String

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -142,37 +142,6 @@ module MnoEnterprise
     # Helper methods
     #============================================
 
-    # test if the provided argument is a id or an uid
-    # @param [Object] id or uid
-    def is_id?(string)
-      string.to_i.to_s == string
-    end
-
-    def parent_organization_id
-      id_or_uid = params[:organization_id]
-      if is_id?(id_or_uid)
-        id_or_uid
-      else
-        parent_organization.id
-      end
-    end
-
-    def parent_organization
-      @parent_organization ||= begin
-        id_or_uid = params[:organization_id]
-        query = is_id?(id_or_uid) ? id_or_uid : { uid: id_or_uid }
-        MnoEnterprise::Organization.find(query).first
-      end
-    end
-
-    def orga_relation
-      @orga_relation ||= begin
-        id_or_uid = params[:organization_id]
-        organization_field = is_id?(id_or_uid) ? 'id' : 'uid'
-        MnoEnterprise::OrgaRelation.where('user.id' => current_user.id, "organization.#{organization_field}" => id_or_uid).first
-      end
-    end
-
     def render_not_found(resource, id = params[:id])
       render json: { errors: { message: "#{resource.titleize} not found (id=#{id})", code: 404, params: params } }, status: :not_found
     end

--- a/core/app/helpers/mno_enterprise/impersonate_helper.rb
+++ b/core/app/helpers/mno_enterprise/impersonate_helper.rb
@@ -22,7 +22,7 @@ module MnoEnterprise
 
     def current_impersonator
       return unless session[:impersonator_user_id]
-      @admin_user ||= MnoEnterprise::User.find_one(session[:impersonator_user_id], :deletion_requests, :organizations, :orga_relations, :dashboards, :teams, :sub_tenant)
+      @admin_user ||= MnoEnterprise::User.find_one(session[:impersonator_user_id])
     end
 
   end

--- a/core/app/models/mno_enterprise/base_resource.rb
+++ b/core/app/models/mno_enterprise/base_resource.rb
@@ -81,6 +81,11 @@ module MnoEnterprise
       @relations ||= ActiveSupport::HashWithIndifferentAccess.new
     end
 
+    # define if the relationship has been loaded (for example by calling include)
+    def relation_loaded?(relation)
+      relationships && relationships.has_attribute?(relation) && relationships[relation].key?('data')
+    end
+
     def process_custom_result(result)
       collect_errors(result.errors)
       raise_if_errors

--- a/core/app/models/mno_enterprise/base_resource.rb
+++ b/core/app/models/mno_enterprise/base_resource.rb
@@ -3,6 +3,7 @@ module MnoEnterprise
 
   class BaseResource < ::JsonApiClient::Resource
     include ActiveModel::Callbacks
+    include JsonApiClientExtension::HasOneExtension
     self.site = URI.join(MnoEnterprise.api_host, MnoEnterprise.mno_api_v2_root_path).to_s
     self.parser = JsonApiClientExtension::CustomParser
 
@@ -75,6 +76,10 @@ module MnoEnterprise
     end
 
     # == Instance Methods ========================================================
+    # cache of the loaded relations, used in JsonApiClientExtension::HasOneExtension
+    def relations
+      @relations ||= ActiveSupport::HashWithIndifferentAccess.new
+    end
 
     def process_custom_result(result)
       collect_errors(result.errors)

--- a/core/app/models/mno_enterprise/deletion_request.rb
+++ b/core/app/models/mno_enterprise/deletion_request.rb
@@ -5,10 +5,19 @@ module MnoEnterprise
 
     custom_endpoint :freeze, on: :member, request_method: :patch
 
+    has_one :deletable
+
     #============================================
     # CONSTANTS
     #============================================
     EXPIRATION_TIME = 60 #minutes
+
+    #============================================
+    # Class methods
+    #============================================
+    def self.active(query = where)
+      query.where('status.ne': 'cancelled', 'created_at.gt': EXPIRATION_TIME.minutes.ago)
+    end
 
     #============================================
     # Instance methods
@@ -26,7 +35,6 @@ module MnoEnterprise
       result = self.freeze
       process_custom_result(result)
     end
-
   end
 end
 

--- a/core/app/models/mno_enterprise/orga_relation.rb
+++ b/core/app/models/mno_enterprise/orga_relation.rb
@@ -9,6 +9,5 @@ module MnoEnterprise
 
     has_one :organization
     has_one :user
-
   end
 end

--- a/core/app/models/mno_enterprise/orga_relation.rb
+++ b/core/app/models/mno_enterprise/orga_relation.rb
@@ -4,8 +4,11 @@ module MnoEnterprise
     property :created_at, type: :time
     property :updated_at, type: :time
     # json_api_client map all primary id as string
-    property :organization_id, type: :string
-    property :user_id, type: :string
+
     property :role, type: :string
+
+    has_one :organization
+    has_one :user
+
   end
 end

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -7,8 +7,6 @@ module MnoEnterprise
     include ActiveModel::AttributeMethods
     include ActiveModel::Validations
 
-    INCLUDED_DEPENDENCIES = %i(deletion_requests organizations orga_relations dashboards teams sub_tenant)
-
     # ids
     property :id
     property :uid, type: :string
@@ -129,7 +127,11 @@ module MnoEnterprise
     end
 
     def orga_relation_from_id(organization_id)
-      MnoEnterprise::OrgaRelation.where('user.id': id, 'organization.id': organization_id).first
+      if relation_loaded?(:orga_relations)
+        self.orga_relations.find { |r| r.organization.id == organization_id }
+      else
+        MnoEnterprise::OrgaRelation.where('user.id': id, 'organization.id': organization_id).first
+      end
     end
 
     def create_deletion_request!

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -129,7 +129,7 @@ module MnoEnterprise
     end
 
     def orga_relation_from_id(organization_id)
-      self.orga_relations.find { |r| r.organization_id == organization_id }
+      MnoEnterprise::OrgaRelation.where('user.id': id, 'organization.id': organization_id).first
     end
 
     def create_deletion_request!

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -105,8 +105,7 @@ module MnoEnterprise
 
     def refresh_user_cache
       self.expire_view_cache
-      reloaded = self.load_required_dependencies
-      Rails.cache.write(['user', reloaded.to_key], reloaded)
+      Rails.cache.write(['user', self.to_key], self)
     end
 
     def load_required_dependencies
@@ -139,11 +138,12 @@ module MnoEnterprise
     end
 
     def current_deletion_request
-      @current_deletion_request ||= if self.account_frozen
-                                      self.deletion_requests.sort_by(&:created_at).last
-                                    else
-                                      self.deletion_requests.select(&:active?).sort_by(&:created_at).first
-                                    end
+      query = if self.account_frozen
+                MnoEnterprise::DeletionRequest.where
+              else
+                MnoEnterprise::DeletionRequest.active
+              end
+      query.where('deletable.id': self.id, 'deletable.type': 'users').order(created_at: :desc).first
     end
 
     def update_password!(input)

--- a/core/lib/json_api_client_extension/has_one_extension.rb
+++ b/core/lib/json_api_client_extension/has_one_extension.rb
@@ -6,14 +6,11 @@ module JsonApiClientExtension::HasOneExtension
       class_eval <<-CODE
         def #{attr_name}_id=(id)
           ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
-          association = id ? {data: {type: "#{attr_name.to_s.pluralize}", id: id.to_s}} : nil
-          self.relationships.#{attr_name} = association
+          super
         end
         def #{attr_name}_id
-          # First we try in the relationship
-          relationship_definitions = self.relationships.try(:#{attr_name})
-          return nil unless relationship_definitions
-          relationship_definitions.dig(:data, :id)
+          ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
+          super
         end
         def #{attr_name}=(relation)
           self.relationships.#{attr_name} = relation

--- a/core/lib/json_api_client_extension/has_one_extension.rb
+++ b/core/lib/json_api_client_extension/has_one_extension.rb
@@ -5,11 +5,13 @@ module JsonApiClientExtension::HasOneExtension
     def has_one(attr_name, options = {})
       class_eval <<-CODE
         def #{attr_name}_id=(id)
-          ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
+          # Uncomment when doing refactoring
+          # ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id= Use relationships instead")
           super
         end
         def #{attr_name}_id
-          ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
+          # Uncomment when doing refactoringgit 
+          # ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
           super
         end
         def #{attr_name}=(relation)

--- a/core/lib/json_api_client_extension/has_one_extension.rb
+++ b/core/lib/json_api_client_extension/has_one_extension.rb
@@ -3,15 +3,15 @@ module JsonApiClientExtension::HasOneExtension
 
   class_methods do
     def has_one(attr_name, options = {})
+      setter_log_warning = (Rails.env.test? || Rails.env.development?) ?  "ActiveSupport::Deprecation.warn('#{self.name}.#{attr_name}_id= Use relationships instead')" : ''
+      getter_log_warning = (Rails.env.test? || Rails.env.development?) ?  "ActiveSupport::Deprecation.warn('#{self.name}.#{attr_name}_id Use relationships instead')" : ''
       class_eval <<-CODE
         def #{attr_name}_id=(id)
-          # Uncomment when doing refactoring
-          # ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id= Use relationships instead")
+          #{setter_log_warning}
           super
         end
         def #{attr_name}_id
-          # Uncomment when doing refactoringgit 
-          # ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
+          #{getter_log_warning}
           super
         end
         def #{attr_name}=(relation)
@@ -21,7 +21,6 @@ module JsonApiClientExtension::HasOneExtension
         def #{attr_name}
           relations[:#{attr_name}] ||= super
         end
-
       CODE
       super
     end

--- a/core/lib/json_api_client_extension/has_one_extension.rb
+++ b/core/lib/json_api_client_extension/has_one_extension.rb
@@ -1,0 +1,30 @@
+module JsonApiClientExtension::HasOneExtension
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def has_one(attr_name, options = {})
+      class_eval <<-CODE
+        def #{attr_name}_id=(id)
+          ActiveSupport::Deprecation.warn(self.class.name + ".#{attr_name}_id Use relationships instead")
+          association = id ? {data: {type: "#{attr_name.to_s.pluralize}", id: id.to_s}} : nil
+          self.relationships.#{attr_name} = association
+        end
+        def #{attr_name}_id
+          # First we try in the relationship
+          relationship_definitions = self.relationships.try(:#{attr_name})
+          return nil unless relationship_definitions
+          relationship_definitions.dig(:data, :id)
+        end
+        def #{attr_name}=(relation)
+          self.relationships.#{attr_name} = relation
+          relations[:#{attr_name}] = relation
+        end
+        def #{attr_name}
+          relations[:#{attr_name}] ||= super
+        end
+
+      CODE
+      super
+    end
+  end
+end

--- a/core/lib/json_api_client_extension/json_api_client_orm_adapter.rb
+++ b/core/lib/json_api_client_extension/json_api_client_orm_adapter.rb
@@ -15,14 +15,14 @@ module JsonApiClient
 
     # @see OrmAdapter::Base#get!
     def get!(id)
-      res = klass.includes(*klass::INCLUDED_DEPENDENCIES).find(wrap_key(id)).first
+      res = klass.find(wrap_key(id)).first
       raise JsonApiClient::Errors::ResourceNotFound, "resource not found" unless res
       res
     end
 
     # @see OrmAdapter::Base#get
     def get(id)
-      res = klass.includes(*klass::INCLUDED_DEPENDENCIES).find(wrap_key(id))
+      res = klass.find(wrap_key(id))
       error = res&.errors&.first
       if (error && error.code != '404')
         raise error.detail

--- a/core/lib/mno_enterprise/concerns/models/ability.rb
+++ b/core/lib/mno_enterprise/concerns/models/ability.rb
@@ -43,20 +43,20 @@ module MnoEnterprise::Concerns::Models::Ability
          :invite_member,
          :administrate,
          :manage_app_instances,
-         :manage_teams], MnoEnterprise::Organization do |organization|
-      ['Super Admin','Admin'].include? user.role(organization)
+         :manage_teams], MnoEnterprise::OrgaRelation do |orga_relation|
+      ['Super Admin','Admin'].include? orga_relation.role
     end
 
     # To be updated
     # TODO: replace by organization_id, no need to load a full organization
-    can :sync_apps, MnoEnterprise::Organization do |organization|
-      user.role(organization)
+    can :sync_apps, MnoEnterprise::OrgaRelation |orga_relation|
+      !!orga_relation
     end
 
     # To be updated
     # TODO: replace by organization_id, no need to load a full organization
-    can :check_apps_sync, MnoEnterprise::Organization do |organization|
-      user.role(organization)
+    can :check_apps_sync, MnoEnterprise::OrgaRelation do |orga_relation|
+      !!orga_relation
     end
 
     #===================================================
@@ -151,7 +151,7 @@ module MnoEnterprise::Concerns::Models::Ability
   # Abilities for admin user
   def admin_abilities(user)
     if user.admin_role.to_s.casecmp('admin').zero? || user.admin_role.to_s.casecmp('staff').zero?
-      can :manage_app_instances, MnoEnterprise::Organization
+      can :manage_app_instances, MnoEnterprise::OrgaRelation
       can :manage_sub_tenant, MnoEnterprise::SubTenant
     end
   end

--- a/core/lib/mno_enterprise/concerns/models/ability.rb
+++ b/core/lib/mno_enterprise/concerns/models/ability.rb
@@ -25,17 +25,15 @@ module MnoEnterprise::Concerns::Models::Ability
     #===================================================
     # Organization
     #===================================================
-    can :create, MnoEnterprise::Organization
+    can :create, MnoEnterprise::OrgaRelation
 
-    can :read, MnoEnterprise::Organization do |organization|
-      !!user.role(organization)
+    can :read, MnoEnterprise::OrgaRelation do |orga_relation|
+      !!orga_relation
     end
 
-    can [:update, :destroy, :manage_billing], MnoEnterprise::Organization do |organization|
-      user.role(organization) == 'Super Admin'
+    can [:update, :destroy, :manage_billing], MnoEnterprise::OrgaRelation do |orga_relation|
+      orga_relation&.role == 'Super Admin'
     end
-
-
 
     # TODO: replace by organization_id, no need to load a full organization, and make user.role accept a string
     can [:upload,
@@ -44,12 +42,12 @@ module MnoEnterprise::Concerns::Models::Ability
          :administrate,
          :manage_app_instances,
          :manage_teams], MnoEnterprise::OrgaRelation do |orga_relation|
-      ['Super Admin','Admin'].include? orga_relation.role
+      orga_relation && ['Super Admin', 'Admin'].include?(orga_relation.role)
     end
 
     # To be updated
     # TODO: replace by organization_id, no need to load a full organization
-    can :sync_apps, MnoEnterprise::OrgaRelation |orga_relation|
+    can :sync_apps, MnoEnterprise::OrgaRelation do |orga_relation|
       !!orga_relation
     end
 
@@ -63,12 +61,14 @@ module MnoEnterprise::Concerns::Models::Ability
     # AppInstance
     #===================================================
     can :access, MnoEnterprise::AppInstance do |app_instance|
-      role = user.role_from_id(app_instance.owner_id)
-      !!role && (
-      ['Super Admin','Admin'].include?(role) ||
-          user.teams.empty? ||
-          user.teams.map(&:app_instances).compact.flatten.map(&:id).include?(app_instance.id)
-      )
+      orga_relation = MnoEnterprise::OrgaRelation.where('user.id': user.id, 'organization.id': app_instance.owner_id).first
+      role = orga_relation&.role
+      if role && ['Super Admin', 'Admin'].include?(role)
+        true
+      else
+        teams = MnoEnterprise::Team.where('users.id': user.id).includes(:app_instances).with_params(fields: { app_instances: 'id' })
+        teams.empty? || teams.map(&:app_instances).compact.flatten.map(&:id).include?(app_instance.id)
+      end
     end
 
     #===================================================
@@ -112,15 +112,15 @@ module MnoEnterprise::Concerns::Models::Ability
   def impac_abilities(user)
     can :manage_impac, MnoEnterprise::Dashboard do |dhb|
       dhb.organizations.any? && dhb.organizations.all? do |org|
-        !!user.role(org) && ['Super Admin', 'Admin'].include?(user.role(org))
+        role = orga_relation(user.id, org.id)&.role
+        role && ['Super Admin', 'Admin'].include?(role)
       end
     end
 
     can :manage_dashboard, MnoEnterprise::Dashboard do |dashboard|
-      if dashboard.owner_type == "Organization"
+      if dashboard.owner_type == 'Organization'
         # The current user is a member of the organization that owns the dashboard that has the kpi attached to
-        owner = MnoEnterprise::Organization.find(dashboard.owner_id)
-        owner && !!user.role(owner)
+        !!orga_relation(user, dashboard.owner_id)
       elsif dashboard.owner_type == "User"
         # The current user is the owner of the dashboard that has the kpi attached to
         dashboard.owner_id == user.id

--- a/core/lib/mno_enterprise/concerns/models/app_instance.rb
+++ b/core/lib/mno_enterprise/concerns/models/app_instance.rb
@@ -28,7 +28,8 @@ module MnoEnterprise::Concerns::Models::AppInstance
   # Class methods
   #==================================================================
   module ClassMethods
-    def provision!(input)
+    def provision!(app_nid, owner_id, owner_type)
+      input = { data: { attributes: { app_nid: app_nid, owner_id: owner_id, owner_type: owner_type} } }
       result = provision(input)
       process_custom_result(result)
     end
@@ -49,7 +50,7 @@ module MnoEnterprise::Concerns::Models::AppInstance
       uid: uid,
       name: name,
       app_nid: app_nid,
-      organization_id: owner_id
+      organization_id: owner.id
     }
   end
 

--- a/core/lib/mno_enterprise/concerns/models/app_instance.rb
+++ b/core/lib/mno_enterprise/concerns/models/app_instance.rb
@@ -11,8 +11,6 @@ module MnoEnterprise::Concerns::Models::AppInstance
     property :updated_at, type: :time
     property :app_id, type: :string
 
-    property :owner_id, type: :string
-
     # delete <api_root>/app_instances/:id/terminate
     custom_endpoint :terminate, on: :member, request_method: :delete
     custom_endpoint :provision, on: :collection, request_method: :post
@@ -22,6 +20,8 @@ module MnoEnterprise::Concerns::Models::AppInstance
     #==============================================================
     ACTIVE_STATUSES = [:running, :stopped, :staged, :provisioning, :starting, :stopping, :updating]
     TERMINATION_STATUSES = [:terminating, :terminated]
+
+    has_one :owner
   end
 
   #==================================================================

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -94,11 +94,6 @@ module MnoEnterprise::Concerns::Models::Organization
     MnoEnterprise::OrgaRelation.create!(organization_id: self.id, user_id: user.id, role: role)
   end
 
-  def provision_app_instance!(app_nid)
-    input = { data: { attributes: { app_nid: app_nid, owner_id: id, owner_type: 'Organization' } } }
-    MnoEnterprise::AppInstance.provision!(input)
-  end
-
   def new_credit_card
     MnoEnterprise::CreditCard.new(owner_id: id, owner_type: 'Organization')
   end

--- a/core/lib/mno_enterprise/testing_support/factories/app_instances.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/app_instances.rb
@@ -25,7 +25,6 @@ FactoryGirl.define do
       per_user_licence 1
       app { build(:app, nid: app_nid) }
       sequence(:owner) { |n| build(:organization, id: n.to_s) }
-      sequence(:owner_id, &:to_s)
     end
   end
 end

--- a/core/lib/mno_enterprise/testing_support/factories/orga_relations.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/orga_relations.rb
@@ -10,5 +10,8 @@ FactoryGirl.define do
     user_id '265'
     organization_id '265'
     role 'Admin'
+    trait :super_admin do
+      role 'Super Admin'
+    end
   end
 end

--- a/core/lib/mno_enterprise/testing_support/factories/product_pricing.rb
+++ b/core/lib/mno_enterprise/testing_support/factories/product_pricing.rb
@@ -14,6 +14,6 @@ FactoryGirl.define do
     per_unit "per unit"
     prices {[]}
     external_id "external id"
-    product_id 1
+    product { build(:product) }
   end
 end

--- a/core/spec/models/mno_enterprise/ability_spec.rb
+++ b/core/spec/models/mno_enterprise/ability_spec.rb
@@ -4,23 +4,20 @@ require 'cancan/matchers'
 # TODO: add more ability tests
 RSpec.describe MnoEnterprise::Ability, type: :model do
   subject(:ability) { described_class.new(user) }
-  let(:user) { FactoryGirl.build(:user, admin_role: admin_role) }
+  let(:user) { build(:user, admin_role: admin_role) }
   let(:admin_role) { nil }
-  let(:organization) { FactoryGirl.build(:organization) }
-
-  before { allow(user).to receive(:role).with(organization) { nil } }
-
+  let(:orga_relation) { build(:orga_relation, role: 'Member') }
   context 'when User#admin_role is admin' do
     let(:admin_role) { 'admin' }
-    it { is_expected.to be_able_to(:manage_app_instances, organization) }
+    it { is_expected.to be_able_to(:manage_app_instances, orga_relation) }
   end
 
   context 'when User#admin_role has a random case' do
     let(:admin_role) { 'ADmIn' }
-    it { is_expected.to be_able_to(:manage_app_instances, organization) }
+    it { is_expected.to be_able_to(:manage_app_instances, orga_relation) }
   end
 
   context 'when no User#admin_role' do
-    it { is_expected.not_to be_able_to(:manage_app_instances, organization) }
+    it { is_expected.not_to be_able_to(:manage_app_instances, orga_relation) }
   end
 end


### PR DESCRIPTION
This PR introduces 2 big changes.

- The use of a has_one relationship helper
- Stop loading everything in current_user

## has_one relationship helper
This PR introduces an helper to easily create elements with relationships. 

```
o = OrgaRelation.new(role: 'Super Admin')
o.relationships.user = User.new(id: user_id)
o.relationships.organization = User.new(id: organization_id)
o.save!
```
is replaced by
 ```
OrgaRelation.create!(user: user, organization: organization, role: 'Super Admin')
```

## make current_user call smaller

In the current version, current_user is preloaded with a lot of dependencies, which are not always used. This can introduce problems of performances, caching and pagination. The objective of this PR is too stop relying on the autoload of theses dependencies and let the controllers manage the loading of what they need.
