### PR TITLE
[MNOE-779] - Filter app_instances on fulfilled_only

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/app_instances_controller.rb
@@ -16,7 +16,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::AppInstancesController
   # GET /mnoe/jpi/v1/organization/1/app_instances
   def index
     statuses = MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')
-    @app_instances = MnoEnterprise::AppInstance.includes(:app).where(owner_id: parent_organization.id, 'status.in': statuses).to_a.select do |i|
+    @app_instances = MnoEnterprise::AppInstance.includes(:app).where(owner_id: parent_organization.id, 'status.in': statuses, 'fulfilled_only': true).to_a.select do |i|
       can?(:access,i)
     end
   end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/app_instances_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/app_instances_controller_spec.rb
@@ -28,7 +28,7 @@ module MnoEnterprise
 
       let(:app_instance) { build(:app_instance, status: 'running' , under_free_trial: false) }
 
-      before { stub_api_v2(:get, '/app_instances', [app_instance], [:app], {filter: {owner_id: organization.id, 'status.in': MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')}}) }
+      before { stub_api_v2(:get, '/app_instances', [app_instance], [:app], {filter: {owner_id: organization.id, 'status.in': MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(','), 'fulfilled_only': true }}) }
 
       before { sign_in user }
       subject { get :index, organization_id: organization.id }
@@ -40,7 +40,7 @@ module MnoEnterprise
           subject
           # TODO: Test that the rendered json is the expected one
           # expect(assigns(:app_instances)).to eq([app_instance])
-          assert_requested(:get, api_v2_url('/app_instances', [:app], {_locale: I18n.locale, filter: {owner_id: organization.id, 'status.in': MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(',')}}))
+          assert_requested(:get, api_v2_url('/app_instances', [:app], {_locale: I18n.locale, filter: {owner_id: organization.id, 'status.in': MnoEnterprise::AppInstance::ACTIVE_STATUSES.join(','), 'fulfilled_only': true }}))
         }
       end
 


### PR DESCRIPTION
Add a filter to retrieve only app_instances fulfilled (having a linked subscription event create/success or not being externally provisioned)

Depends on: https://github.com/maestrano/maestrano-hub/pull/805