### PR TITLE
[MNOE-783] Fix registration route not being loaded

### DIFF
--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -53,11 +53,10 @@ module MnoEnterprise
     end
 
     devise_modules = [
-      :remote_authenticatable, :recoverable, :rememberable,
+      :remote_authenticatable, :recoverable, :rememberable, :registerable,
       :trackable, :validatable, :lockable, :confirmable, :timeoutable, :password_expirable,
       :omniauthable
     ]
-    devise_modules << :registerable if Settings&.dashboard&.registration&.enabled
     devise(*devise_modules, omniauth_providers: Devise.omniauth_providers)
 
     #================================

--- a/core/spec/models/mno_enterprise/user_spec.rb
+++ b/core/spec/models/mno_enterprise/user_spec.rb
@@ -322,31 +322,8 @@ module MnoEnterprise
     describe 'Devise' do
       subject { MnoEnterprise::User.new }
       describe 'registerable?' do
-        context 'default' do
-          before { reload_user }
-          it 'is registerable' do
+        it 'is registerable' do
             expect(MnoEnterprise::User.ancestors).to include(Devise::Models::Registerable)
-          end
-        end
-
-        context 'enabled' do
-          before do
-            Settings.merge!(dashboard: { registration: { disabled: true } })
-            reload_user
-          end
-          it 'is registerable' do
-            expect(MnoEnterprise::User.ancestors).to include(Devise::Models::Registerable)
-          end
-        end
-
-        context 'disabled' do
-          before do
-            Settings.merge!(dashboard: { registration: { enabled: false } })
-            reload_user
-          end
-          it 'is not registerable' do
-            expect(MnoEnterprise::User.ancestors).not_to include(Devise::Models::Registerable)
-          end
         end
       end
     end


### PR DESCRIPTION
Fix an issue when the registration is disabled in the settings.yml and
then enabled via the MnoHub settings.
Since the routes are being build based on the User#devise_modules which
is built when loading the class, the registration route is never added.

The Devise::Models::Registerable is only adding a class method to the
user model (.new_with_session), so it's ok to always add it.