### PR TITLE
[MNOE-611] Inactive Apps should not be exposed on API

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/apps_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/apps_controller.rb
@@ -15,7 +15,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::AppsController
   #==================================================================
   # GET /mnoe/jpi/v1/admin/apps
   def index
-    query = MnoEnterprise::App.apply_query_params(params).where(scope: 'all').select(*FIELDS)
+    query = MnoEnterprise::App.apply_query_params(params).where(scope: 'all', active: true).select(*FIELDS)
     @apps = MnoEnterprise::App.fetch_all(query)
     response.headers['X-Total-Count'] = query.meta.record_count
   end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/apps_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/apps_controller_spec.rb
@@ -19,7 +19,7 @@ module MnoEnterprise
     let(:app) { build(:app) }
 
     describe 'GET #index' do
-      before { stub_api_v2(:get, '/apps', [app], [], {fields: {apps: [:name, :id, :logo, :nid, :tiny_description].join(',')}, filter: {scope: 'all'}}) }
+      before { stub_api_v2(:get, '/apps', [app], [], {fields: {apps: [:name, :id, :logo, :nid, :tiny_description].join(',')}, filter: {scope: 'all', active: true}}) }
 
       subject { get :index }
 


### PR DESCRIPTION
The goal of this PR is to prevent inactive apps to appear on the apps selection screen in the admin panel.