### PR TITLE
Try to find member from id first

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/organizations_controller.rb
@@ -165,6 +165,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::OrganizationsController
 
   protected
   def member
+    @member ||= organization.users.find { |u| u.id == params.require(:member).permit(:id) }
     @member ||= begin
       email = params.require(:member).require(:email)
       # Organizations are already loaded with all users


### PR DESCRIPTION
For a very specific use case:
In the admin panel, we will be able to modify the user email and their role within an organization.

If we modify the email first, the frontend model will store the new email value, even if the user still needs to click on the confirmation link they will receive.
Therefore, if we try to update the role, we won't be able to find the user from the new email (MnoHub will keep the old email until the new one has been confirmed)