### PR TITLE
[MNOE-776] Ability to update_member and remove_member from admin

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
@@ -212,6 +212,8 @@ module MnoEnterprise
     end
 
     def requested_user_in_org(organization)
+      # If a user has updated their email address, but has not clicked on the confirmation link yet,
+      # we won't find them from their email, so we look from their id first.
       user = organization.users.find { |u| u.id == params.require(:member)[:id] }
       user ||= begin
         email = params.require(:member).require(:email)

--- a/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_member_or_invite.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_member_or_invite.json.jbuilder
@@ -1,0 +1,13 @@
+if member.is_a?(MnoEnterprise::User)
+  json.id member.id
+  json.entity 'User'
+  json.name member.name
+  json.surname member.surname
+  json.email member.email
+  json.role organization.role(member)
+elsif member.is_a?(MnoEnterprise::OrgaInvite)
+  json.id member.id
+  json.entity 'OrgInvite'
+  json.email member.user_email
+  json.role member.user_role
+end

--- a/api/app/views/mno_enterprise/jpi/v1/admin/organizations/members.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/organizations/members.json.jbuilder
@@ -1,0 +1,3 @@
+json.members do
+  json.partial! 'member_or_invite', collection: @organization.members, as: :member, organization: @organization
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -252,6 +252,8 @@ MnoEnterprise::Engine.routes.draw do
           end
           member do
             post :users, action: :invite_member
+            put :update_member
+            put :remove_member
             put :freeze
             put :unfreeze
           end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/organizations_controller_spec.rb
@@ -4,6 +4,7 @@ module MnoEnterprise
   describe Jpi::V1::OrganizationsController, type: :controller do
     include MnoEnterprise::TestingSupport::JpiV1TestHelper
     include MnoEnterprise::TestingSupport::OrganizationsSharedHelpers
+    include MnoEnterprise::TestingSupport::SharedExamples::OrganizationSharedExamples
 
     render_views
     routes { MnoEnterprise::Engine.routes }
@@ -82,19 +83,19 @@ module MnoEnterprise
 
       context 'contains invoices' do
         subject { get :show, id: organization.id }
-        
+
         let(:money) { Money.new(0, 'AUD') }
         let(:role) { 'Super Admin' }
         let(:member_role) { role }
         let(:member) { build(:user, id: user.id, email: user.email) }
-        
+
         before {
           allow_any_instance_of(MnoEnterprise::Organization).to receive(:current_billing).and_return(money)
           allow_any_instance_of(MnoEnterprise::Organization).to receive(:current_credit).and_return(money)
           organization.invoices << invoice
-          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices)) 
+          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
         }
-      
+
         it 'renders the list of invoices' do
           subject
           expect(JSON.parse(response.body)['invoices']).to eq(partial_hash_for_invoices(organization))
@@ -275,161 +276,24 @@ module MnoEnterprise
       end
     end
 
-    describe 'PUT #update_member' do
-
-      let(:email) { 'somemember@maestrano.com' }
-      let(:member_role) { 'Member' }
-      let(:member) { build(:user) }
-      let(:email) { member.email }
-
-      let(:new_member_role) { 'Power User' }
-      let(:params) { {email: email, role: new_member_role} }
-
-      # reloading organization
+    describe 'update and remove member' do
       before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
 
-      subject { put :update_member, id: organization.id, member: params }
-      it_behaves_like 'jpi v1 authorizable action'
-      it_behaves_like 'an organization management action'
+      describe 'PUT #update_member' do
+        subject { put :update_member, id: organization.id, member: { email: 'abc' } }
 
-      context 'with user' do
-        let(:member_orga_relation) { build(:orga_relation, user_id: member.id, organization_id: organization.id, role: member_role) }
-        let(:organization_stub) {
-          organization.users << member
-          organization.orga_relations << member_orga_relation
-          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
-        }
-        before { stub_api_v2(:get, "/orga_relations", [member_orga_relation], [], {filter: {organization_id: organization.id, user_id: member.id}, page:{ number: 1, size: 1}}) }
-        before { stub_api_v2(:post, "/orga_relations/#{member_orga_relation.id}", orga_relation) }
-        before { stub_api_v2(:patch, "/orga_relations/#{member_orga_relation.id}") }
-
-        # Happy path
-        it 'updates the member role' do
-          subject
-        end
-        # Exceptions
-        context 'when admin' do
-          let(:role) { 'Admin' }
-          context 'assign super admin role' do
-            let(:new_member_role) { 'Super Admin' }
-            it 'denies access' do
-              expect(subject).to_not be_successful
-              expect(subject.code).to eq('403')
-            end
-          end
-          context 'edit super admin' do
-            let(:member_role) { 'Super Admin' }
-            let(:new_member_role) { 'Member' }
-            it 'denies access' do
-              expect(subject).to_not be_successful
-              expect(subject.code).to eq('403')
-            end
-          end
-        end
-
-        context 'last super admin changing his role' do
-          let(:role) { 'Super Admin' }
-          let(:member_role) { role }
-          let(:member) { build(:user, id: user.id, email: user.email) }
-          let(:new_member_role) { 'Member' }
-          it 'denies access' do
-            expect(subject).to_not be_successful
-            expect(subject.code).to eq('403')
-          end
-        end
+        it_behaves_like 'jpi v1 authorizable action'
+        it_behaves_like 'an organization management action'
       end
 
-      context 'with invite' do
-        let(:orga_invite) { build(:orga_invite, user_id: member.id, organization_id: organization.id, user_role: member_role, status: 'pending', user_email: email) }
-        let!(:organization_stub) {
-          organization.orga_invites << orga_invite
-          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
-        }
+      describe 'PUT #remove_member' do
+        subject { put :remove_member, id: organization.id, member: { email: 'abc' } }
 
-        before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices)) }
-        # reloading organization
-        before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
-
-        # Happy Path
-        it 'updates the member role' do
-          expect_any_instance_of(MnoEnterprise::OrgaInvite).to receive(:update_attributes).with(user_role: params[:role])
-          subject
-        end
-
-        # Exceptions
-        context 'when admin' do
-          let(:role) { 'Admin' }
-          context 'assign super admin role' do
-            let(:member_role) { 'Super Admin' }
-            it 'denies access' do
-              expect(subject).to_not be_successful
-              expect(subject.code).to eq('403')
-            end
-          end
-
-          context 'edit super admin' do
-            let(:member_role) { 'Super Admin' }
-            let(:new_member_role) { 'Member' }
-
-            it 'denies access' do
-              expect(subject).to_not be_successful
-              expect(subject.code).to eq('403')
-            end
-          end
-        end
+        it_behaves_like 'jpi v1 authorizable action'
+        it_behaves_like 'an organization management action'
       end
 
-      it 'renders a the user list' do
-        subject
-        expect(JSON.parse(response.body)).to eq({'members' => partial_hash_for_members(organization)})
-      end
-    end
-
-    describe 'PUT #remove_member' do
-
-      let(:member) { build(:user) }
-      let(:member_orga_relation) { build(:orga_relation, user_id: member.id, organization_id: organization.id) }
-
-      let!(:organization_stub) {
-        organization.users << member
-        organization.orga_relations << member_orga_relation
-        stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
-      }
-      # reloading organization
-      before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
-
-
-      let(:params) { {email: 'somemember@maestrano.com'} }
-      subject { put :remove_member, id: organization.id, member: params }
-
-      it_behaves_like 'jpi v1 authorizable action'
-      it_behaves_like 'an organization management action'
-
-      context 'with user' do
-        before { stub_api_v2(:delete, "/orga_relations/#{member_orga_relation.id}") }
-        let(:params) { {email: member.email} }
-        it 'removes the member' do
-          subject
-        end
-      end
-
-      context 'with invite' do
-        let(:orga_invite) { build(:orga_invite, user_id: member.id, organization_id: organization.id, status: 'pending', user_email: member.email) }
-        let!(:organization_stub) {
-          organization.orga_invites << orga_invite
-          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
-        }
-
-        before { stub_api_v2(:get, "/orga_invites/#{orga_invite.id}/decline")}
-        it 'removes the member' do
-          subject
-        end
-      end
-
-      it 'renders a the user list' do
-        subject
-        expect(JSON.parse(response.body)).to eq({'members' => partial_hash_for_members(organization)})
-      end
+      it_behaves_like 'organization update and remove'
     end
   end
 end

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -87,9 +87,9 @@ module MnoEnterprise::Concerns::Models::Organization
 
   # Update a user role within self
   #
-  # user - A MnoEnterprise::User who performed the action
-  # updated_user - The user to update. ∈ [MnoEnterprise::User, MnoEnterprise::OrgaInvite]
-  # new_role - The role to assign to updated_user
+  # @param user [MnoEnterprise::User] the user performing the action
+  # @param updated_user [MnoEnterprise::User, MnoEnterprise::OrgaInvite] the user to update
+  # @param new_role [String] the role to assign to updated_user
   #
   def update_user_role(user, updated_user, new_role)
     if user.role(self) == 'Admin'

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -85,37 +85,37 @@ module MnoEnterprise::Concerns::Models::Organization
     }
   end
 
-  # Update a user role within self on behalf on user_updating
+  # Update a user role within self
   #
-  # user_updating - A MnoEnterprise::User who performed the action
-  # user_to_update - The user to update. ∈ [MnoEnterprise::User, MnoEnterprise::OrgaInvite]
-  # new_role - The role to assign to user_to_update
+  # user - A MnoEnterprise::User who performed the action
+  # updated_user - The user to update. ∈ [MnoEnterprise::User, MnoEnterprise::OrgaInvite]
+  # new_role - The role to assign to updated_user
   #
-  def update_user_role(user_updating, user_to_update, new_role)
-    if user_updating.role(self) == 'Admin'
+  def update_user_role(user, updated_user, new_role)
+    if user.role(self) == 'Admin'
       # Admin cannot assign Super Admin role
       raise CanCan::AccessDenied if new_role == 'Super Admin'
-      current_role = if user_to_update.is_a?(MnoEnterprise::User)
-                          role(user_to_update)
-                        elsif user_to_update.is_a?(MnoEnterprise::OrgaInvite)
-                          user_to_update.user_role
+      current_role = if updated_user.is_a?(MnoEnterprise::User)
+                          role(updated_user)
+                        elsif updated_user.is_a?(MnoEnterprise::OrgaInvite)
+                          updated_user.user_role
                         end
       # Admin cannot edit Super Admin
       if current_role == 'Super Admin'
         raise CanCan::AccessDenied
       end
-    elsif user_to_update.id == user_updating.id && new_role != 'Super Admin' && orga_relations.count { |u| u.role == 'Super Admin' } <= 1
+    elsif updated_user.id == user.id && new_role != 'Super Admin' && orga_relations.count { |u| u.role == 'Super Admin' } <= 1
       # A super admin cannot modify his role if he's the last super admin
       raise CanCan::AccessDenied
     end
 
     # Happy Path
-    case user_to_update
+    case updated_user
     when MnoEnterprise::User
-      orga_relation = orga_relations.find { |rel| rel.user_id == user_to_update.id }
+      orga_relation = orga_relations.find { |rel| rel.user_id == updated_user.id }
       orga_relation.update_attributes!(role: new_role)
     when MnoEnterprise::OrgaInvite
-      user_to_update.update_attributes!(user_role: new_role)
+      updated_user.update_attributes!(user_role: new_role)
     end
   end
 

--- a/core/lib/mno_enterprise/testing_support/shared_examples/organization_shared_examples.rb
+++ b/core/lib/mno_enterprise/testing_support/shared_examples/organization_shared_examples.rb
@@ -1,0 +1,157 @@
+module MnoEnterprise::TestingSupport::SharedExamples::OrganizationSharedExamples
+  include MnoEnterprise::TestingSupport::JpiV1TestHelper
+
+  shared_examples 'organization update and remove' do
+    describe 'PUT #update_member' do
+
+      let(:email) { 'somemember@maestrano.com' }
+      let(:member_role) { 'Member' }
+      let(:member) { build(:user) }
+      let(:email) { member.email }
+
+      let(:new_member_role) { 'Power User' }
+      let(:params) { {email: email, role: new_member_role} }
+
+      # reloading organization
+      before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
+
+      subject { put :update_member, id: organization.id, member: params }
+
+      context 'with user' do
+        let(:member_orga_relation) { build(:orga_relation, user_id: member.id, organization_id: organization.id, role: member_role) }
+        let(:organization_stub) {
+          organization.users << member
+          organization.orga_relations << member_orga_relation
+          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
+        }
+        before { stub_api_v2(:get, "/orga_relations", [member_orga_relation], [], {filter: {organization_id: organization.id, user_id: member.id}, page:{ number: 1, size: 1}}) }
+        before { stub_api_v2(:post, "/orga_relations/#{member_orga_relation.id}", orga_relation) }
+        before { stub_api_v2(:patch, "/orga_relations/#{member_orga_relation.id}") }
+
+        # Happy path
+        it 'updates the member role' do
+          subject
+        end
+        # Exceptions
+        context 'when admin' do
+          let(:role) { 'Admin' }
+          context 'assign super admin role' do
+            let(:new_member_role) { 'Super Admin' }
+            it 'denies access' do
+              expect(subject).to_not be_successful
+              expect(subject.code).to eq('403')
+            end
+          end
+          context 'edit super admin' do
+            let(:member_role) { 'Super Admin' }
+            let(:new_member_role) { 'Member' }
+            it 'denies access' do
+              expect(subject).to_not be_successful
+              expect(subject.code).to eq('403')
+            end
+          end
+        end
+
+        context 'last super admin changing his role' do
+          let(:role) { 'Super Admin' }
+          let(:member_role) { role }
+          let(:member) { build(:user, id: user.id, email: user.email) }
+          let(:new_member_role) { 'Member' }
+          it 'denies access' do
+            expect(subject).to_not be_successful
+            expect(subject.code).to eq('403')
+          end
+        end
+      end
+
+      context 'with invite' do
+        let(:orga_invite) { build(:orga_invite, user_id: member.id, organization_id: organization.id, user_role: member_role, status: 'pending', user_email: email) }
+        let!(:organization_stub) {
+          organization.orga_invites << orga_invite
+          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
+        }
+
+        before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices)) }
+        # reloading organization
+        before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
+
+        # Happy Path
+        it 'updates the member role' do
+          expect_any_instance_of(MnoEnterprise::OrgaInvite).to receive(:update_attributes).with(user_role: params[:role])
+          subject
+        end
+
+        # Exceptions
+        context 'when admin' do
+          let(:role) { 'Admin' }
+          context 'assign super admin role' do
+            let(:member_role) { 'Super Admin' }
+            it 'denies access' do
+              expect(subject).to_not be_successful
+              expect(subject.code).to eq('403')
+            end
+          end
+
+          context 'edit super admin' do
+            let(:member_role) { 'Super Admin' }
+            let(:new_member_role) { 'Member' }
+
+            it 'denies access' do
+              expect(subject).to_not be_successful
+              expect(subject.code).to eq('403')
+            end
+          end
+        end
+      end
+
+      it 'renders the user list' do
+        subject
+        expect(JSON.parse(response.body)).to eq({'members' => partial_hash_for_members(organization)})
+      end
+    end
+
+    describe 'PUT #remove_member' do
+
+      let(:member) { build(:user) }
+      let(:member_orga_relation) { build(:orga_relation, user_id: member.id, organization_id: organization.id) }
+
+      let!(:organization_stub) {
+        organization.users << member
+        organization.orga_relations << member_orga_relation
+        stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
+      }
+      # reloading organization
+      before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }
+
+
+      let(:params) { {email: 'somemember@maestrano.com'} }
+      subject { put :remove_member, id: organization.id, member: params }
+
+      context 'with user' do
+        before { stub_api_v2(:delete, "/orga_relations/#{member_orga_relation.id}") }
+        let(:params) { {email: member.email} }
+        it 'removes the member' do
+          subject
+        end
+      end
+
+      context 'with invite' do
+        let(:orga_invite) { build(:orga_invite, user_id: member.id, organization_id: organization.id, status: 'pending', user_email: member.email) }
+        let!(:organization_stub) {
+          organization.orga_invites << orga_invite
+          stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations credit_card invoices))
+        }
+
+        before { stub_api_v2(:get, "/orga_invites/#{orga_invite.id}/decline")}
+        it 'removes the member' do
+          subject
+        end
+      end
+
+      it 'renders a the user list' do
+        subject
+        expect(JSON.parse(response.body)).to eq({'members' => partial_hash_for_members(organization)})
+      end
+    end
+  end
+end

--- a/core/lib/mno_enterprise/testing_support/shared_examples/organization_shared_examples.rb
+++ b/core/lib/mno_enterprise/testing_support/shared_examples/organization_shared_examples.rb
@@ -10,7 +10,7 @@ module MnoEnterprise::TestingSupport::SharedExamples::OrganizationSharedExamples
       let(:email) { member.email }
 
       let(:new_member_role) { 'Power User' }
-      let(:params) { {email: email, role: new_member_role} }
+      let(:params) { {id: member.id, email: email, role: new_member_role} }
 
       # reloading organization
       before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, %i(users orga_invites orga_relations)) }


### PR DESCRIPTION
Needed PUT #update_member and PUT #remove_member actions in admin controller for organizations

=> Move update_member logic in organization model
=> Create shared example for these two methods in a new file