### PR TITLE
Impac! permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 **Dependencies:**
 
-Requires MnoHub containing [maestrano/maestrano-hub#269](https://github.com/maestrano/maestrano-hub/pull/269) (eg: v2.0.0-rc7+)
+Requires MnoHub containing
+- [maestrano/maestrano-hub#269](https://github.com/maestrano/maestrano-hub/pull/269) (eg: v2.0.0-rc7+)
+- [maestrano/maestrano-hub#818](https://github.com/maestrano/maestrano-hub/pull/818) (eg: v2.0.0-rc8+)
 
 **Implemented enhancements:**
 

--- a/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.cache! ['v1', @user.cache_key] do
+json.cache! ['v2', @user.cache_key] do
   json.current_user do
     json.id @user.id
     json.name @user.name
@@ -28,7 +28,7 @@ json.cache! ['v1', @user.cache_key] do
     # Embed association if user is persisted
     if @user.id
       json.organizations do
-        json.array! (@user.organizations.active || []) do |o|
+        json.array! (@user.organizations.active.include_acl || []) do |o|
           json.id o.id
           json.uid o.uid
           json.name o.name
@@ -36,6 +36,7 @@ json.cache! ['v1', @user.cache_key] do
           json.current_user_role o.role
           json.has_myob_essentials_only o.has_myob_essentials_only?
           json.financial_year_end_month o.financial_year_end_month
+          json.acl o.acl
         end
       end
 

--- a/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/current_users/show.json.jbuilder
@@ -28,7 +28,7 @@ json.cache! ['v2', @user.cache_key] do
     # Embed association if user is persisted
     if @user.id
       json.organizations do
-        json.array! (@user.organizations.active.include_acl || []) do |o|
+        json.array! (@user.organizations.active.include_acl(session[:impersonator_user_id]) || []) do |o|
           json.id o.id
           json.uid o.uid
           json.name o.name

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/alerts_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/alerts_controller.rb
@@ -19,8 +19,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::AlertsController
   def create
     return render_bad_request('attach alert to kpi', 'no alert specified') unless params.require(:alert)
     return render_not_found('kpi') unless kpi_alert.kpi
-
-    authorize! :manage_alert, kpi_alert
+    authorize! :update_impac_kpis, kpi_alert.kpi
 
     if (@alert = current_user.alerts.create(kpi_alert.attributes))
       render 'show'
@@ -33,10 +32,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::AlertsController
   def update
     return render_bad_request('update alert attributes', 'no alert hash specified') unless params.require(:alert)
     return render_not_found('alert') unless alert
+    authorize! :update_impac_kpis, alert.kpi
 
     attributes = params.require(:alert).permit(:title, :webhook, :sent)
-
-    authorize! :manage_alert, alert
 
     if alert.update(attributes)
       render 'show'
@@ -48,8 +46,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::AlertsController
   # DELETE /jpi/v1/impac/alerts/:id
   def destroy
     return render_not_found('alert') unless alert
-
-    authorize! :manage_alert, alert
+    authorize! :update_impac_kpis, alert.kpi
 
     service = alert.service
     if alert.destroy

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -145,7 +145,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
     def kpi_create_params
       whitelist = [:dashboard_id, :widget_id, :endpoint, :source, :element_watched, {extra_watchables: []}]
       create_params = extract_params(whitelist)
-      create_params[:settings][:organization_ids] ||= kpi_parent.settings[:organization_ids]
+      create_params[:settings][:organization_ids] ||= kpi_parent.settings.to_h[:organization_ids]
       create_params
     end
 

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/impac/kpis_controller.rb
@@ -49,16 +49,15 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
   # POST /mnoe/jpi/v1/impac/dashboards/:dashboard_id/kpis
   #   -> POST /api/mnoe/v1/dashboards/:id/kpis
   #   -> POST /api/mnoe/v1/users/:id/alerts
+  # TODO: nest alert in as a param, with the current user as a recipient.
   def create
     if params[:kpi][:widget_id].present?
       return render_not_found('widget') if widget.blank?
-      authorize! :manage_widget, widget
     else
       return render_not_found('dashboard') if dashboard.blank?
-      authorize! :manage_dashboard, dashboard
     end  
+    authorize! :create_impac_kpis, kpi_parent.kpis.build(kpi_create_params)
 
-    # TODO: nest alert in as a param, with the current user as a recipient.
     @kpi = kpi_parent.kpis.create(kpi_create_params)
     unless kpi.errors?
       # Creates a default alert for kpis created with targets defined.
@@ -80,8 +79,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
   #   -> PUT /api/mnoe/v1/kpis/:id
   def update
     render_not_found('kpi') unless kpi.present?
-
-    authorize! :manage_kpi, kpi
+    authorize! :update_impac_kpis, kpi
 
     params = kpi_update_params
 
@@ -113,8 +111,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
   #   -> DELETE /api/mnoe/v1/kpis/:id
   def destroy
     render_not_found('kpi') unless kpi.present?
-
-    authorize! :manage_kpi, kpi
+    authorize! :destroy_impac_kpis, kpi
 
     if kpi.destroy
       head status: :ok
@@ -147,7 +144,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Impac::KpisController
 
     def kpi_create_params
       whitelist = [:dashboard_id, :widget_id, :endpoint, :source, :element_watched, {extra_watchables: []}]
-      extract_params(whitelist)
+      create_params = extract_params(whitelist)
+      create_params[:settings][:organization_ids] ||= kpi_parent.settings[:organization_ids]
+      create_params
     end
 
     def kpi_update_params

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
@@ -75,6 +75,7 @@ module MnoEnterprise
       api_stub_for(get: '/sub_tenants', response: from_api([sub_tenant]))
       api_stub_for(get: "/sub_tenants/#{sub_tenant.id}", response: from_api(sub_tenant))
       api_stub_for(get: "/users/#{current_user.id}", response: from_api(current_user))
+      api_stub_for(get: "/users/#{current_user.id}/organizations", response: from_api([organization]))
       sign_in current_user
     end
 
@@ -121,17 +122,21 @@ module MnoEnterprise
     describe 'PUT #update' do
       subject { put :update, id: sub_tenant.id, sub_tenant: {name: 'new name'} }
 
-
       before do
         api_stub_for(get: "/sub_tenants/#{sub_tenant.id}", response: from_api(sub_tenant))
         api_stub_for(put: "/sub_tenants/#{sub_tenant.id}", response: -> { sub_tenant.name = 'new name'; from_api(sub_tenant) })
         sign_in current_user
       end
+
+      it_behaves_like 'a jpi v1 admin action' do
+        before { api_stub_for(get: "/users/#{user.id}/organizations", response: from_api([organization])) }
+      end
+
       context 'not admin' do
         let(:current_user) { build(:user) }
         it_behaves_like 'unauthorized access'
       end
-      it_behaves_like 'a jpi v1 admin action'
+      
       context 'admin' do
         before { subject }
         context 'success' do
@@ -141,6 +146,7 @@ module MnoEnterprise
         end
       end
     end
+
     describe 'DELETE #destroy' do
       subject { delete :destroy, id: sub_tenant.id }
       before do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/current_users_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/current_users_controller_spec.rb
@@ -46,7 +46,8 @@ module MnoEnterprise
               'currency' => 'AUD',
               'current_user_role' => o.role,
               'has_myob_essentials_only' => o.has_myob_essentials_only?,
-              'financial_year_end_month' => o.financial_year_end_month
+              'financial_year_end_month' => o.financial_year_end_month,
+              'acl' => o.acl
           }
         end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/dashboards_controller_spec.rb
@@ -37,6 +37,7 @@ module MnoEnterprise
       end
     end
 
+    let!(:ability) { stub_ability }
     let(:user) { build(:user, :with_organizations) }
     let(:org) { build(:organization, users: [user]) }
     let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
@@ -130,6 +131,10 @@ module MnoEnterprise
     end
 
     describe 'POST #create' do
+      subject { post :create, user_id: user.id, dashboard: dashboard_params }
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+      
       before do
         api_stub_for(
           post: "users/#{user.id}/dashboards",
@@ -140,20 +145,24 @@ module MnoEnterprise
           get: "users/#{user.id}/dashboards",
           response: from_api([dashboard])
         )
+        allow(ability).to receive(:can?).with(:create_impac_dashboards, any_args).and_return(true)
       end
-      include_context "#{described_class}: dashboard dependencies stubs"
-
-      subject { post :create, user_id: user.id, dashboard: dashboard_params }
 
       it_behaves_like "jpi v1 protected action"
 
-      it 'returns a dashboard' do
-        subject
-        expect(JSON.parse(response.body)).to eq(hash_for_dashboard)
+      context 'when authorized' do
+        it 'returns a dashboard' do
+          subject
+          expect(JSON.parse(response.body)).to eq(hash_for_dashboard)
+        end
       end
     end
 
     describe 'PUT #update' do
+      subject { put :update, id: dashboard.id, dashboard: dashboard_params }
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+
       before do
         api_stub_for(
           get: "users/#{user.id}/dashboards/#{dashboard.id}",
@@ -163,10 +172,8 @@ module MnoEnterprise
           put: "dashboards/#{dashboard.id}",
           response: from_api(dashboard)
         )
+        allow(ability).to receive(:can?).with(:update_impac_dashboards, any_args).and_return(true)
       end
-      include_context "#{described_class}: dashboard dependencies stubs"
-
-      subject { put :update, id: dashboard.id, dashboard: dashboard_params }
 
       it_behaves_like "jpi v1 protected action"
 
@@ -177,6 +184,10 @@ module MnoEnterprise
     end
 
     describe "DELETE destroy" do
+      subject { delete :destroy, id: dashboard.id }
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+      
       before do
         api_stub_for(
           get: "users/#{user.id}/dashboards/#{dashboard.id}",
@@ -186,15 +197,17 @@ module MnoEnterprise
           delete: "dashboards/#{dashboard.id}",
           response: from_api(dashboard)
         )
+        allow(ability).to receive(:can?).with(:destroy_impac_dashboards, any_args).and_return(true)
       end
-      include_context "#{described_class}: dashboard dependencies stubs"
-
-      subject { delete :destroy, id: dashboard.id }
       
       it_behaves_like "jpi v1 protected action"
     end
 
     describe 'POST copy' do
+      subject { post :copy, id: template.id, dashboard: dashboard_params }
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+      
       let(:template) { build(:impac_dashboard, dashboard_type: 'template') }
 
       before do
@@ -207,10 +220,8 @@ module MnoEnterprise
           post: "/dashboards/#{template.id}/copy",
           response: from_api(dashboard)
         )
+        allow(ability).to receive(:can?).with(:create_impac_dashboards, any_args).and_return(true)
       end
-      include_context "#{described_class}: dashboard dependencies stubs"
-
-      subject { post :copy, id: template.id, dashboard: dashboard_params }
 
       it_behaves_like "jpi v1 protected action"
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/impac/kpis_controller_spec.rb
@@ -78,7 +78,6 @@ module MnoEnterprise
 
     describe 'POST #create' do
       shared_examples "create kpi action" do
-
         it "creates the kpi" do
           subject
           expect(assigns(:kpi)).to eq(kpi)
@@ -88,6 +87,8 @@ module MnoEnterprise
       end
 
       let (:kpi_targets) { {} }
+
+      before { allow(ability).to receive(:can?).with(:create_impac_kpis, any_args).and_return(true) }
 
       context "a dashboard KPI" do
         subject { post :create, dashboard_id: dashboard.id, kpi: kpi_hash }
@@ -170,6 +171,8 @@ module MnoEnterprise
     end
 
     describe 'PUT #update' do
+      subject { put :update, id: kpi.id, kpi: kpi_hash.merge(params) }
+
       RSpec.shared_examples 'a kpi update action' do
         it "updates the kpi" do
           subject
@@ -233,15 +236,13 @@ module MnoEnterprise
       let(:kpi_hash) { from_api(kpi)[:data].except(:dashboard).merge(element_watched: 'New Watchable') }
       let(:params) { {} }
 
-      subject { put :update, id: kpi.id, kpi: kpi_hash.merge(params) }
-
       before do
         api_stub_for(get: "/kpis/#{kpi.id}", response: from_api(kpi))
         api_stub_for(put: "/kpis/#{kpi.id}", response: kpi_hash)
         api_stub_for(get: "/kpis/#{kpi.id}/alerts", response: from_api(alerts_hashes))
+        allow(ability).to receive(:can?).with(:update_impac_kpis, any_args).and_return(true)
+        kpi.save
       end
-
-      before { kpi.save }
 
       context "a dashboard KPI" do
         it_behaves_like "jpi v1 authorizable action"
@@ -260,8 +261,11 @@ module MnoEnterprise
     describe 'DELETE #destroy' do
       subject { delete :destroy, id: kpi.id }
 
-      before { api_stub_for(get: "/kpis/#{kpi.id}", response: from_api(kpi)) }
-      before { api_stub_for(delete: "/kpis/#{kpi.id}", response: {message: 'ok', code: 200}) }
+      before do
+        api_stub_for(get: "/kpis/#{kpi.id}", response: from_api(kpi))
+        api_stub_for(delete: "/kpis/#{kpi.id}", response: {message: 'ok', code: 200})
+        allow(ability).to receive(:can?).with(:destroy_impac_kpis, any_args).and_return(true)
+      end
 
       it_behaves_like "jpi v1 authorizable action"
 

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -30,7 +30,7 @@ module MnoEnterprise
     end
 
     def current_ability
-      MnoEnterprise::Ability.new(current_user)
+      MnoEnterprise::Ability.new(current_user, session)
     end
 
     def set_default_meta

--- a/core/app/models/mno_enterprise/impac/dashboard.rb
+++ b/core/app/models/mno_enterprise/impac/dashboard.rb
@@ -22,13 +22,13 @@ module MnoEnterprise
     end
 
     # Return all the organizations linked to this dashboard and to which the user has access
-    # If the dashboard is a template, return all the current user's organization
+    # If the dashboard is a template, return all the current user's organizations
     def organizations(org_list = nil)
       if org_list
         return org_list if dashboard_type == 'template'
-        org_list.to_a.select { |e| self.organization_ids.include?(e.uid) }
+        org_list.to_a.select { |e| organization_ids.include?(e.uid) || organization_ids.include?(e.id) }
       else
-        MnoEnterprise::Organization.where('uid.in' => self.organization_ids).to_a
+        MnoEnterprise::Organization.where('uid.in' => organization_ids).to_a
       end
     end
 

--- a/core/app/models/mno_enterprise/impac/dashboard.rb
+++ b/core/app/models/mno_enterprise/impac/dashboard.rb
@@ -44,10 +44,7 @@ module MnoEnterprise
     end
 
     def to_audit_event
-      {
-        name: name,
-        organization_id: (owner_type == 'Organization') ? owner_id : nil
-      }
+      { name: name }
     end
 
     def copy(owner, name, organization_ids)

--- a/core/app/models/mno_enterprise/impac/kpi.rb
+++ b/core/app/models/mno_enterprise/impac/kpi.rb
@@ -7,5 +7,18 @@ module MnoEnterprise
     belongs_to :widget, class_name: 'MnoEnterprise::Impac::Widget'
     has_many :alerts, class_name: 'MnoEnterprise::Impac::Alert'
 
+    def organizations(orgs = nil)
+      if orgs.present?
+        orgs.select { |org| organization_ids.include?(org.uid) }.to_a
+      else
+        MnoEnterprise::Organization.where('uid.in' => organization_ids).to_a
+      end
+    end
+
+    private
+
+    def organization_ids
+      @organization_ids ||= (settings.present? && settings['organization_ids']).to_a
+    end
   end
 end

--- a/core/app/models/mno_enterprise/impac/widget.rb
+++ b/core/app/models/mno_enterprise/impac/widget.rb
@@ -8,15 +8,26 @@ module MnoEnterprise
     has_many :kpis, class_name: 'MnoEnterprise::Impac::Kpi'
 
     def to_audit_event
-
-      if settings.present? && settings['organization_ids'].present?
-        organization = MnoEnterprise::Organization.find_by(uid: settings['organization_ids'].first)
+      if organization_ids.present?
+        organization = MnoEnterprise::Organization.find_by(uid: organization_ids.first)
         { name: name, organization_id: organization.id }
       else
         { name: name }
       end
-
     end
 
+    def organizations(orgs = nil)
+      if orgs.present?
+        orgs.select { |org| organization_ids.include?(org.uid) }.to_a
+      else
+        MnoEnterprise::Organization.where('uid.in' => organization_ids).to_a
+      end
+    end
+
+    private
+
+    def organization_ids
+      @organization_ids ||= (settings.present? && settings['organization_ids']).to_a
+    end
   end
 end

--- a/core/lib/mno_enterprise/concerns/models/ability.rb
+++ b/core/lib/mno_enterprise/concerns/models/ability.rb
@@ -66,15 +66,15 @@ module MnoEnterprise::Concerns::Models::Ability
     end
 
     #===================================================
-    # Admin abilities
-    #===================================================
-    admin_abilities(user)
-
-    #===================================================
     # Impac
     #===================================================
     orgs_with_acl = user.organizations.active.include_acl(session[:impersonator_user_id]).to_a
     impac_abilities(orgs_with_acl)
+
+    #===================================================
+    # Admin abilities
+    #===================================================
+    admin_abilities(user)
   end
 
   # Abilities for admin user
@@ -88,47 +88,65 @@ module MnoEnterprise::Concerns::Models::Ability
   def impac_abilities(orgs_with_acl)
     can :create_impac_dashboards, MnoEnterprise::Impac::Dashboard do |d|
       orgs = d.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :dashboards, :create) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:dashboards] && org.acl[:related][:dashboards][:create]
+      end
     end
 
     can :update_impac_dashboards, MnoEnterprise::Impac::Dashboard do |d|
       orgs = d.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :dashboards, :update) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:dashboards] && org.acl[:related][:dashboards][:update]
+      end
     end
 
     can :destroy_impac_dashboards, MnoEnterprise::Impac::Dashboard do |d|
       orgs = d.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :dashboards, :destroy) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:dashboards] && org.acl[:related][:dashboards][:destroy]
+      end
     end
 
     can :create_impac_widgets, MnoEnterprise::Impac::Widget do |w|
       orgs = w.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :widgets, :create) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:widgets] && org.acl[:related][:widgets][:create]
+      end
     end
 
     can :update_impac_widgets, MnoEnterprise::Impac::Widget do |w|
       orgs = w.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :widgets, :update) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:widgets] && org.acl[:related][:widgets][:update]
+      end
     end
 
     can :destroy_impac_widgets, MnoEnterprise::Impac::Widget do |w|
       orgs = w.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :widgets, :destroy) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:widgets] && org.acl[:related][:widgets][:destroy]
+      end
     end
 
     can :create_impac_kpis, MnoEnterprise::Impac::Kpi do |k|
       orgs = k.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :kpis, :create) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:kpis] && org.acl[:related][:kpis][:create]
+      end
     end
 
     can :update_impac_kpis, MnoEnterprise::Impac::Kpi do |k|
       orgs = k.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :kpis, :update) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:kpis] && org.acl[:related][:kpis][:update]
+      end
     end
 
     can :destroy_impac_kpis, MnoEnterprise::Impac::Kpi do |k|
       orgs = k.organizations(orgs_with_acl)
-      orgs.present? && orgs.all? { |org| org.acl.dig(:related, :kpis, :destroy) }
+      orgs.present? && orgs.all? do |org|
+        org.acl[:related] && org.acl[:related][:kpis] && org.acl[:related][:kpis][:destroy]
+      end
     end
   end
 end

--- a/core/lib/mno_enterprise/concerns/models/ability.rb
+++ b/core/lib/mno_enterprise/concerns/models/ability.rb
@@ -66,10 +66,26 @@ module MnoEnterprise::Concerns::Models::Ability
     end
 
     #===================================================
+    # Admin abilities
+    #===================================================
+    admin_abilities(user)
+
+    #===================================================
     # Impac
     #===================================================
     orgs_with_acl = user.organizations.active.include_acl(session[:impersonator_user_id]).to_a
+    impac_abilities(orgs_with_acl)
+  end
 
+  # Abilities for admin user
+  def admin_abilities(user)
+    if user.admin_role.to_s.casecmp('admin').zero? || user.admin_role.to_s.casecmp('staff').zero?
+      can :manage_app_instances, MnoEnterprise::Organization
+    end
+  end
+
+  # Enables / disables Impac! Angular capabilities
+  def impac_abilities(orgs_with_acl)
     can :create_impac_dashboards, MnoEnterprise::Impac::Dashboard do |d|
       orgs = d.organizations(orgs_with_acl)
       orgs.present? && orgs.all? { |org| org.acl.dig(:related, :dashboards, :create) }
@@ -113,18 +129,6 @@ module MnoEnterprise::Concerns::Models::Ability
     can :destroy_impac_kpis, MnoEnterprise::Impac::Kpi do |k|
       orgs = k.organizations(orgs_with_acl)
       orgs.present? && orgs.all? { |org| org.acl.dig(:related, :kpis, :destroy) }
-    end
-
-    #===================================================
-    # Admin abilities
-    #===================================================
-    admin_abilities(user)
-  end
-
-  # Abilities for admin user
-  def admin_abilities(user)
-    if user.admin_role.to_s.casecmp('admin').zero? || user.admin_role.to_s.casecmp('staff').zero?
-      can :manage_app_instances, MnoEnterprise::Organization
     end
   end
 end

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -41,7 +41,7 @@ module MnoEnterprise::Concerns::Models::Organization
 
     scope :in_arrears, -> { where(in_arrears?: true) }
     scope :active, -> { where(account_frozen: false) }
-    scope :include_acl, -> { tap { |x| x.params[:include_acl?] = true } }
+    scope :include_acl, ->(imp_id) { tap { |x| x.params.merge!(include_acl?: true, account_manager_id: imp_id) } }
     default_scope lambda { where(account_frozen: false) }
 
     #================================

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -37,12 +37,11 @@ module MnoEnterprise::Concerns::Models::Organization
   included do
     attributes :uid, :name, :account_frozen, :free_trial_end_at, :soa_enabled, :mails, :logo,
       :latitude, :longitude, :geo_country_code, :geo_state_code, :geo_city, :geo_tz, :geo_currency,
-      :meta_data, :industry, :size, :financial_year_end_month
+      :meta_data, :industry, :size, :financial_year_end_month, :acl
 
     scope :in_arrears, -> { where(in_arrears?: true) }
-
     scope :active, -> { where(account_frozen: false) }
-
+    scope :include_acl, -> { tap { |x| x.params[:include_acl?] = true } }
     default_scope lambda { where(account_frozen: false) }
 
     #================================

--- a/core/spec/models/mno_enterprise/ability_spec.rb
+++ b/core/spec/models/mno_enterprise/ability_spec.rb
@@ -3,12 +3,35 @@ require 'cancan/matchers'
 
 # TODO: add more ability tests
 RSpec.describe MnoEnterprise::Ability, type: :model do
-  subject(:ability) { described_class.new(user) }
+  subject(:ability) { described_class.new(user, session) }
   let(:user) { FactoryGirl.build(:user, admin_role: admin_role) }
+  let(:user2) { FactoryGirl.build(:user) }
+  let(:session) { { impersonator_user_id: user2.id } }
   let(:admin_role) { nil }
   let(:organization) { FactoryGirl.build(:organization) }
+  
+  let(:org1) { FactoryGirl.build(:organization, acl: acl) }
+  let(:org2) { FactoryGirl.build(:organization, acl: acl) }
+  let(:acl) do
+    {
+      self: { show: false, update: false, destroy: false },
+      related: {
+        impac: { show: false },
+        dashboards: { show: false, create: false, update: false, destroy: false },
+        widgets: { show: false, create: false, update: false, destroy: false },
+        kpis: { show: false, create: false, update: false, destroy: false },
+      }
+    }
+  end
+  let(:orgs_with_acl) { [org1, org2] }
+  let(:orgs_ids) { orgs_with_acl.map(&:uid) }
 
-  before { allow(user).to receive(:role).with(organization) { nil } }
+  before do
+    allow(user).to receive(:role).with(organization) { nil }
+    allow(user).to receive(:organizations).and_return(
+      double(:active, active: double(:include_acl, include_acl: orgs_with_acl))
+    )
+  end
 
   context 'when User#admin_role is admin' do
     let(:admin_role) { 'admin' }
@@ -22,5 +45,40 @@ RSpec.describe MnoEnterprise::Ability, type: :model do
 
   context 'when no User#admin_role' do
     it { is_expected.not_to be_able_to(:manage_app_instances, organization) }
+  end
+
+  describe 'Impac! abilities' do
+    %i(dashboards widgets kpis).each do |component|
+      %i(create update destroy).each do |action|
+        context "when at least one organization cannot #{action} #{component}" do
+          before { org1.acl[:related][component][action] = true }
+
+          it do
+            impac_component = FactoryGirl.build(
+              "impac_#{component}".singularize.to_sym,
+              settings: { organization_ids: orgs_ids },
+              organization_ids: orgs_ids
+            )
+            is_expected.not_to be_able_to("#{action}_impac_#{component}".to_sym, impac_component)
+          end
+        end
+
+        context "when all the organizations can #{action} #{component}" do
+          before do
+            org1.acl[:related][component][action] = true
+            org2.acl[:related][component][action] = true
+          end
+
+          it do
+            impac_component = FactoryGirl.build(
+              "impac_#{component}".singularize.to_sym,
+              settings: { organization_ids: orgs_ids },
+              organization_ids: orgs_ids
+            )
+            is_expected.to be_able_to("#{action}_impac_#{component}".to_sym, impac_component)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] mention dependency to mnohub: https://github.com/maestrano/maestrano-hub/pull/818

- Modify `current_user` so ACL is attached to each organization
- Can pass the impersonator id to get the **impersonator's** access rights instead of the user's ones
- Add CanCan abilities to restrict the actions on Impac! controllers