### PR TITLE
JsonApiClient fixes for 1.5.3

### DIFF
--- a/core/app/models/mno_enterprise/base_resource.rb
+++ b/core/app/models/mno_enterprise/base_resource.rb
@@ -108,11 +108,8 @@ module MnoEnterprise
     end
 
     def destroy!
-      unless destroy
-        # HotFix waiting for #https://github.com/chingor13/json_api_client/pull/275 to be merged
-        collect_errors(last_result_set.errors)
-        raise_if_errors
-      end
+      destroy
+      raise_if_errors
     end
 
     def collect_errors(external_errors)

--- a/core/config/initializers/json_api_client.rb
+++ b/core/config/initializers/json_api_client.rb
@@ -1,0 +1,3 @@
+# Configure pagination params
+JsonApiClient::Paginating::Paginator.page_param = 'number'
+JsonApiClient::Paginating::Paginator.per_page_param = 'size'

--- a/core/mno-enterprise-core.gemspec
+++ b/core/mno-enterprise-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 4.2', '>= 4.2.0'
   s.add_dependency 'httparty', '~> 0.11'
-  s.add_dependency 'json_api_client', '~> 1.5.2'
+  s.add_dependency 'json_api_client', '~> 1.5.3'
   s.add_dependency 'countries', '~> 1.2.5'
   s.add_dependency 'jwt', '~> 1.4'
   s.add_dependency 'deepstruct', '~> 0.0.7'


### PR DESCRIPTION
* Bump min version to 1.5.3
* Default pagination params changed in 1.5.3. See https://github.com/chingor13/json_api_client/pull/267
* Remove JsonApiClient monkey patch. See https://github.com/chingor13/json_api_client/pull/275