### PR TITLE
[MNOE-823] "Account Manager" feature flag

### DIFF
--- a/core/lib/generators/mno_enterprise/install/templates/config/settings.yml
+++ b/core/lib/generators/mno_enterprise/install/templates/config/settings.yml
@@ -81,4 +81,6 @@ admin_panel:
     enabled: true
   sub_tenant:
     enabled: false
+  account_manager:
+    enabled: false
 


### PR DESCRIPTION
This add a new "Account Manager" feature flag

If the feature is enabled, a "staff" user can be assigned to customers and can only see those ones (which is the current behaviour)
If the feature is disabled, the screen to assign customers is not showing and a staff can see all customers (only difference with "admin" in this case is some screens are limited)