### PR TITLE
[MNOE-776] Fix issues with invitation management

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
@@ -131,6 +131,7 @@ module MnoEnterprise
         status: 'staged' # Will be updated to 'accepted' for unconfirmed users
       )
       invite = invite.load_required(:user)
+      @organization = @organization.load_required(:orga_relations) unless user.confirmed?
       @user = user.confirmed? ? invite : user
     end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -155,6 +155,7 @@ module MnoEnterprise
         before { allow(invited_user).to receive(:confirmed?).and_return(false) }
         before { allow(controller).to receive(:create_unconfirmed_user).and_return(invited_user) }
         before { allow(orga_invite).to receive(:user).and_return(invited_user) }
+        before { stub_api_v2(:get, "/organizations/#{organization.id}", organization, [:orga_relations]) }
         before { stub_api_v2(:get, '/users', nil, [:orga_relations], { filter: { email: params[:email] }, page: { number: 1, size: 1 } }) }
         before { stub_api_v2(:get, "/orga_invites/#{orga_invite.id}", orga_invite, [:user]) }
         before { expect(MnoEnterprise::OrgaInvite).to receive(:create).and_return(orga_invite) }


### PR DESCRIPTION
- For the invite_member, organisation.orga_relations were not up to date with the new orga relation created from the orga invite. Then, when returning the json, this line was nil: https://github.com/manu-d/mno-enterprise/blob/4.0/api/app/views/mno_enterprise/jpi/v1/admin/base_resource/_member.json.jbuilder#L4, so we couldn't get the value on the frontend