### PR TITLE
[MNOE-110] Fix health check when MnoHub is down

### DIFF
--- a/api/app/controllers/mno_enterprise/status_controller.rb
+++ b/api/app/controllers/mno_enterprise/status_controller.rb
@@ -1,6 +1,10 @@
 # Health Check endpoint
 module MnoEnterprise
   class StatusController < ApplicationController
+    # Skip filters than rely on MnoHub (RemoteAuthenticatable)
+    skip_before_filter :handle_password_change
+    skip_before_filter :perform_return_to
+
     # Simple check to see that the app is up
     # Returns:
     #   {status: 'Ok'}

--- a/api/config/initializers/health_check.rb
+++ b/api/config/initializers/health_check.rb
@@ -31,3 +31,11 @@ HealthCheck.setup do |config|
     MnoEnterprise::HealthCheck.perform_mno_hub_check
   end
 end
+
+# Monkey patch HealthCheckController to skip filters than rely on MnoHub (RemoteAuthenticatable)
+module HealthCheck
+  class HealthCheckController
+    skip_before_filter :handle_password_change
+    skip_before_filter :perform_return_to
+  end
+end

--- a/api/spec/controllers/mno_enterprise/status_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/status_controller_spec.rb
@@ -18,7 +18,6 @@ module MnoEnterprise
       it { is_expected.to respond_with(200) }
 
       it 'returns the main app version' do
-        puts MnoEnterprise::APP_VERSION
         expect(data['app-version']).to eq(MnoEnterprise::APP_VERSION)
       end
 

--- a/api/spec/requests/mno_enterprise/healthcheck_spec.rb
+++ b/api/spec/requests/mno_enterprise/healthcheck_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  # Test the Status controller is still working when MnoHub is down
+  # The behavior is tested in the ControllerSpec
+  RSpec.describe "Health Check", type: :request do
+    include MnoEnterprise::TestingSupport::RequestSpecHelper
+
+    describe 'simple' do
+      subject { get '/mnoe/health_check.json' }
+      let(:data) { JSON.parse(response.body) }
+
+      context 'with a signed in user' do
+        include_context 'signed in user'
+
+        context 'when MnoHub is up' do
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok), response.body }
+          it { expect(data['healthy']).to be true }
+        end
+
+        context 'when MnoHub is down' do
+          before { clear_api_stubs }
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok), response.body }
+          it { expect(data['healthy']).to be true }
+        end
+      end
+    end
+
+    describe 'full' do
+      subject { get '/mnoe/health_check/full.json' }
+      let(:data) { JSON.parse(response.body) }
+
+      context 'with a signed in user' do
+        include_context 'signed in user'
+
+        context 'when MnoHub is up' do
+          before { api_stub_for(get: '/apps?limit=1&sort[]=id.asc', response: from_api([FactoryGirl.build(:app)])) }
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok), response.body }
+          it { expect(data['healthy']).to be true }
+        end
+
+        context 'when MnoHub is down' do
+          before { clear_api_stubs }
+          before { subject }
+
+          it { expect(response).to have_http_status(:internal_server_error), response.body }
+          it { expect(data['healthy']).to be false }
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/mno_enterprise/status_spec.rb
+++ b/api/spec/requests/mno_enterprise/status_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  # Test the Status controller is still working when MnoHub is down
+  # The behavior is tested in the ControllerSpec
+  RSpec.describe "Status", type: :request do
+    include MnoEnterprise::TestingSupport::RequestSpecHelper
+
+    describe 'version' do
+      subject { get '/mnoe/version' }
+      let(:data) { JSON.parse(response.body) }
+
+      context 'with a signed in user' do
+        include_context 'signed in user'
+
+        context 'when MnoHub is up' do
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
+
+        context 'when MnoHub is down' do
+          before { clear_api_stubs }
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
+      end
+
+      context 'without a signed in user' do
+        before { subject }
+        it { expect(response).to have_http_status(:ok) }
+      end
+    end
+
+    describe 'ping' do
+      subject { get '/mnoe/ping' }
+
+      context 'with a signed in user' do
+        include_context 'signed in user'
+
+        context 'when MnoHub is up' do
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
+
+        context 'when MnoHub is down' do
+          before { clear_api_stubs }
+          before { subject }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
+      end
+
+      context 'without a signed in user' do
+        before { subject }
+        it { expect(response).to have_http_status(:ok) }
+      end
+    end
+  end
+end

--- a/core/lib/mno_enterprise/testing_support/request_spec_helper.rb
+++ b/core/lib/mno_enterprise/testing_support/request_spec_helper.rb
@@ -1,0 +1,20 @@
+# Helpers used in Request Specs
+module MnoEnterprise::TestingSupport::RequestSpecHelper
+  shared_context 'signed in user' do
+    # Simulate a user login by login through devise
+    def login
+      # Stub user manipulation
+      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
+      api_stub_for(put: "/users/#{user.id}", response: from_api(user))
+
+      # Stub session authentication
+      api_stub_for(post: '/user_sessions', code: 200, response: from_api(user))
+
+      # Log in
+      post '/mnoe/auth/users/sign_in', user: {email: user.email, password: 'securepassword'}
+    end
+
+    let(:user) { FactoryGirl.build(:user, password_valid: true) }
+    before { login }
+  end
+end


### PR DESCRIPTION
Fix version and health check endpoint when MnoHub is down.
If a valid session cookie was present, some before filters were dependent on MnoHub which would cause 500 errors.