### PR TITLE
[MNOE-744] Better authorisation error reporting

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/base_resource_controller.rb
@@ -20,10 +20,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::BaseResourceControl
   # Check current user is logged in
   # Check organization is valid if specified
   def check_authorization
-    if current_user && current_user.admin_role.present?
-      return true
-    end
-    render nothing: true, status: :unauthorized
+    return true if current_user && current_user.admin_role.present?
+    status = current_user ? :forbidden : :unauthorized
+    render nothing: true, status: status
     false
   end
 

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/sub_tenants_controller_spec.rb
@@ -26,14 +26,6 @@ module MnoEnterprise
       }
     end
 
-    shared_examples_for 'unauthorized access' do
-      it { expect(subject).to_not be_success }
-      it do
-        subject
-        expect(response.status).to eq(401)
-      end
-    end
-
     #===============================================
     # Specs
     #===============================================
@@ -43,21 +35,16 @@ module MnoEnterprise
 
     describe '#index' do
       subject { get :index }
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
-      context 'admin' do
-        context 'success' do
-          before do
-            stub_api_v2(:get, "/sub_tenants", [sub_tenant])
-            sign_in user
-          end
-          before { subject }
-          it 'returns a list of sub_tenant' do
-            expect(response).to be_success
-            expect(JSON.parse(response.body)).to eq(JSON.parse(hash_for_sub_tenants([sub_tenant]).to_json))
-          end
+
+      before { stub_api_v2(:get, "/sub_tenants", [sub_tenant]) }
+
+      it_behaves_like 'a jpi v1 admin action'
+
+      context 'success' do
+        before { sign_in user }
+
+        it 'returns a list of sub_tenant' do
+          expect(JSON.parse(subject.body)).to eq(JSON.parse(hash_for_sub_tenants([sub_tenant]).to_json))
         end
       end
     end
@@ -65,111 +52,80 @@ module MnoEnterprise
     describe 'GET #show' do
       subject { get :show, id: sub_tenant.id }
 
-      before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-      end
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
-      context 'admin' do
-        it_behaves_like 'a jpi v1 admin action'
-        context 'success' do
-          before do
-            sign_in user
-            subject
-          end
-          it 'returns a complete description of the sub_tenant' do
-            expect(response).to be_success
-            expect(JSON.parse(response.body)).to eq(JSON.parse(hash_for_sub_tenant(sub_tenant).to_json))
-          end
+      before { stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
+
+      it_behaves_like 'a jpi v1 admin action'
+
+      context 'success' do
+        before { sign_in user }
+        it 'returns a complete description of the sub_tenant' do
+          expect(response).to be_success
+          expect(JSON.parse(subject.body)).to eq(JSON.parse(hash_for_sub_tenant(sub_tenant).to_json))
         end
       end
     end
 
     describe 'PUT #update' do
       subject { put :update, id: sub_tenant.id, sub_tenant: { name: 'new name' } }
-      before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-        sign_in user
-      end
+
+      before { stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
       let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
+
       it_behaves_like 'a jpi v1 admin action'
-      context 'admin' do
-        context 'success' do
-          before { subject }
-          it { expect(response).to be_success }
-          it { expect(stub).to have_been_requested }
-        end
+
+      context 'success' do
+        before { sign_in user }
+        before { subject }
+        it { expect(response).to be_success }
+        it { expect(stub).to have_been_requested }
       end
     end
 
     describe 'PATCH #update_clients' do
       subject { put :update_clients, id: sub_tenant.id, sub_tenant: { add: [] } }
-      before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-        sign_in user
-      end
+
+      before { stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
       let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}/update_clients", sub_tenant) }
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
+
       it_behaves_like 'a jpi v1 admin action'
-      context 'admin' do
-        context 'success' do
-          before { subject }
-          it { expect(response).to be_success }
-          it { expect(stub).to have_been_requested }
-        end
+
+      context 'success' do
+        before { sign_in user }
+        before { subject }
+        it { expect(response).to be_success }
+        it { expect(stub).to have_been_requested }
       end
     end
 
     describe 'PATCH #update_account_managers' do
       subject { put :update_account_managers, id: sub_tenant.id, sub_tenant: { add: [] } }
-      before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-        sign_in user
-      end
+
+      before { stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
       let!(:stub) { stub_api_v2(:patch, "/sub_tenants/#{sub_tenant.id}/update_account_managers", sub_tenant) }
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
+
       it_behaves_like 'a jpi v1 admin action'
-      context 'admin' do
-        context 'success' do
-          before { subject }
-          it { expect(response).to be_success }
-          it { expect(stub).to have_been_requested }
-        end
+
+      context 'success' do
+        before { sign_in user }
+        before { subject }
+        it { expect(response).to be_success }
+        it { expect(stub).to have_been_requested }
       end
     end
 
     describe 'DELETE #destroy' do
       subject { delete :destroy, id: sub_tenant.id }
-      before do
-        stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant)
-        sign_in user
-      end
+
+      before { stub_api_v2(:get, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
       let!(:stub) { stub_api_v2(:delete, "/sub_tenants/#{sub_tenant.id}", sub_tenant) }
 
       it_behaves_like 'a jpi v1 admin action'
 
-      context 'not admin' do
-        let!(:user) { build(:user) }
-        it_behaves_like 'unauthorized access'
-      end
-      context 'admin' do
-        context 'success' do
-          before { subject }
-          it { expect(response).to be_success }
-          it { expect(stub).to have_been_requested }
-        end
+      context 'success' do
+        before { sign_in user  }
+        before { subject }
+        it { expect(response).to be_success }
+        it { expect(stub).to have_been_requested }
       end
     end
   end

--- a/core/lib/mno_enterprise/testing_support/shared_examples/jpi_v1_admin.rb
+++ b/core/lib/mno_enterprise/testing_support/shared_examples/jpi_v1_admin.rb
@@ -5,7 +5,7 @@ module MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
 
       it "prevents access" do
         expect(subject).to_not be_successful
-        expect(subject.code).to eq('401')
+        expect(subject).to have_http_status(:unauthorized)
       end
     end
 
@@ -18,7 +18,7 @@ module MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
 
       it "prevents access" do
         expect(subject).to_not be_successful
-        expect(subject.code).to eq('401')
+        expect(subject).to have_http_status(:forbidden)
       end
     end
 


### PR DESCRIPTION
This enables us to differentiate between unauthenticated users and authenticated users which are not admin. We'll be able to handle them differently in the frontend (redirect to sign_in or customer view).

**Dependency:**
This requires a change in the admin panel to handle 403 errors.  Do not merge.
Fixed in maestrano/mnoe-admin-panel#189