### PR TITLE
[MNOE-865] Send patch request to correct MnoHub endpoints for reviews

### DIFF
--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_reviews_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/app_reviews_controller_spec.rb
@@ -49,8 +49,9 @@ module MnoEnterprise
     end
 
     describe 'PUT #update' do
+      let(:review) { build(:feedback) }
       subject { put :update, id: review.id, app_review: {status: 'rejected'} }
-      let!(:patch_stub) { stub_api_v2(:patch, "/reviews/#{review.id}", review) }
+      let!(:patch_stub) { stub_api_v2(:patch, "/feedbacks/#{review.id}", review) }
       let!(:get_stub) { stub_api_v2(:get, "/reviews/#{review.id}", review) }
       it_behaves_like 'a jpi v1 admin action'
 

--- a/core/app/models/mno_enterprise/review.rb
+++ b/core/app/models/mno_enterprise/review.rb
@@ -3,5 +3,18 @@ module MnoEnterprise
     property :created_at, type: :time
     property :updated_at, type: :time
     property :user_id, type: :string
+
+    # Since Review is the parent metaclass for Comment, Feedback, Question & Answer,
+    # we need to send the request to the appropriate endpoint
+    def self.path(params = nil)
+      @type_param = params[:type] if params
+      res = super
+      @type_param = nil
+      res
+    end
+
+    def self.resource_path
+      @type_param || super
+    end
   end
 end


### PR DESCRIPTION
On MnoHub side, json_api_resource needs the type of the payload to be the same as the type in the controller path, i.e 
<pre><json>
{  
   "data":{  
      "id":"1",
      "type":"<b>comments</b>",
      "attributes":{  
         "description":"Great app",
         "user_id":"1"
      }
   }
}
</pre>
needs to be sent to /api/mnoe/v2/**comments**/1 