### PR TITLE
Revert "[MNOE-833] - Fix wrong entity sent back on user creation"

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/organizations_controller.rb
@@ -80,7 +80,7 @@ module MnoEnterprise
         status: 'staged' # Will be updated to 'accepted' for unconfirmed users
       )
 
-      @user = user.confirmed? ? user.reload : invite
+      @user = user.confirmed? ? invite : user.reload
     end
 
     protected

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -180,7 +180,6 @@ module MnoEnterprise
         # Directly stubbing the controller method as user creation is a PITA to stub
         let(:new_user) { build(:user, params.slice(:email, :name, :surname, :phone)) }
         before { allow(controller).to receive(:create_unconfirmed_user) { new_user } }
-        before { api_stub_for(get: "/users/#{new_user.id}", response: new_user) }
 
         it_behaves_like 'a jpi v1 admin action'
 


### PR DESCRIPTION
Reverts maestrano/mno-enterprise#602

Reverting as per my comment on MNOE-833. It introduces a regression and doesn't fix the original problem.