### PR TITLE
[MNOE-910] Fix 500 error found in MNOE

### DIFF
--- a/api/lib/mno_enterprise/audit_events_listener.rb
+++ b/api/lib/mno_enterprise/audit_events_listener.rb
@@ -15,11 +15,10 @@ module MnoEnterprise
       organization_id = if (subject_type == 'MnoEnterprise::Organization') then
                           subject_id
                         elsif metadata.is_a?(Hash)
-                          metadata[:organization_id].presence
+                          metadata["organization_id"].presence
                         end
       data[:organization_id] = organization_id if organization_id
       MnoEnterprise::AuditEvent.create(data)
     end
   end
 end
-

--- a/api/lib/mno_enterprise/intercom_events_listener.rb
+++ b/api/lib/mno_enterprise/intercom_events_listener.rb
@@ -27,15 +27,15 @@ module MnoEnterprise
           data[:event_name] = 'removed-widget'
         when 'widget_create'
           data[:event_name] = 'added-widget'
-          data[:metadata] = {widget: metadata[:name]}
+          data[:metadata] = {widget: metadata["name"]}
         when 'app_launch'
-          data[:event_name] = 'launched-app-' + metadata[:app_nid]
+          data[:event_name] = 'launched-app-' + metadata["app_nid"]
         when 'app_destroy'
-          data[:event_name] = 'deleted-app-'  + metadata[:app_nid]
-          data[:metadata] = {type: 'single', app_list: metadata[:app_nid]}
+          data[:event_name] = 'deleted-app-'  + metadata["app_nid"]
+          data[:metadata] = {type: 'single', app_list: metadata["app_nid"]}
         when 'app_add'
-          data[:event_name] = 'added-app-' + metadata[:app_nid]
-          data[:metadata] = {type: 'single', app_list: metadata[:app_nid]}
+          data[:event_name] = 'added-app-' + metadata["app_nid"]
+          data[:metadata] = {type: 'single', app_list: metadata["app_nid"]}
       end
       # Update user data in intercom
       # OPTIMIZE: we could fetch the user for intercom and only update fields that have changed
@@ -85,4 +85,3 @@ module MnoEnterprise
     end
   end
 end
-


### PR DESCRIPTION
Metadata hash was turned into JSON, and then was accessed with a symbol. JSON objects can only be accessed with strings.  