### PR TITLE
[MNOE-909]Removed trackable for impersonation requests

### DIFF
--- a/api/app/controllers/mno_enterprise/impersonate_controller.rb
+++ b/api/app/controllers/mno_enterprise/impersonate_controller.rb
@@ -2,6 +2,7 @@ module MnoEnterprise
   class ImpersonateController < ApplicationController
     include MnoEnterprise::ImpersonateHelper
 
+    before_filter :skip_trackable, only: [:create]
     before_filter :authenticate_user!, except: [:destroy]
     before_filter :current_user_must_be_admin!, except: [:destroy]
 
@@ -38,6 +39,10 @@ module MnoEnterprise
     end
 
     private
+
+    def skip_trackable
+      request.env["devise.skip_trackable"] = true
+    end
 
     def current_user_must_be_admin!
       unless current_user.admin_role.present?

--- a/api/app/controllers/mno_enterprise/impersonate_controller.rb
+++ b/api/app/controllers/mno_enterprise/impersonate_controller.rb
@@ -2,7 +2,7 @@ module MnoEnterprise
   class ImpersonateController < ApplicationController
     include MnoEnterprise::ImpersonateHelper
 
-    before_filter :skip_trackable, only: [:create]
+    before_filter :skip_devise_trackable!, only: [:create]
     before_filter :authenticate_user!, except: [:destroy]
     before_filter :current_user_must_be_admin!, except: [:destroy]
 
@@ -39,10 +39,6 @@ module MnoEnterprise
     end
 
     private
-
-    def skip_trackable
-      request.env["devise.skip_trackable"] = true
-    end
 
     def current_user_must_be_admin!
       unless current_user.admin_role.present?

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -66,8 +66,12 @@ module MnoEnterprise
     # user action and should therefore be taken into account
     def skip_devise_trackable_on_xhr
       if request.format == 'application/json' && request.get?
-        request.env["devise.skip_trackable"] = true
+        skip_devise_trackable!
       end
+    end
+
+    def skip_devise_trackable!
+      request.env["devise.skip_trackable"] = true
     end
 
     # Return the user to the 'return_to' url if one was specified


### PR DESCRIPTION
Devise makes it easy to skip trackable. Just need to set request.env["devise.skip_trackable"] = true, BEFORE authentication happens. Tested locally and works.

It is appropriate to put it in the impersonate_controller, rather than the general auth-controller because we specifically want to do this on impersonating. 

If we wanted to skip trackable other times, we could consider moving it into `sessions_controller.rb` and having an `if params[:skip_trackable]`.