### PR TITLE
[MNOE-926] Fix Dashboards backward compatibility

### DIFF
--- a/core/app/models/mno_enterprise/dashboard.rb
+++ b/core/app/models/mno_enterprise/dashboard.rb
@@ -53,7 +53,7 @@ module MnoEnterprise
     end
 
     def sorted_widgets
-      ids = self.widgets_order | self.widgets.map(&:id)
+      ids = self.widgets_order.map(&:to_s) | self.widgets.map(&:id)
       widgets_per_ids = self.widgets.each_with_object({}) do |w, hash|
         hash[w.id] = w
       end

--- a/core/spec/models/mno_enterprise/dashboard_spec.rb
+++ b/core/spec/models/mno_enterprise/dashboard_spec.rb
@@ -11,7 +11,30 @@ module MnoEnterprise
     end
 
     describe '#sorted_widgets' do
-      it 'is pending'
+      let(:w1) { build(:impac_widget) }
+      let(:w2) { build(:impac_widget) }
+      let(:w3) { build(:impac_widget) }
+
+      let(:dashboard) { build(:impac_dashboard, organization_ids: [org1.uid], widgets: [w1, w2, w3]) }
+
+      subject { dashboard.sorted_widgets }
+
+      context 'without #widgets_order' do
+        it { is_expected.to eq([w1, w2, w3])}
+      end
+
+      context 'with a #widget_order' do
+        before { dashboard.widgets_order = [w3.id, w2.id]}
+        # unsorted widgets at the end
+        it { is_expected.to eq([w3, w2, w1])}
+
+        context 'APIv1 backward compatibility' do
+          # APIv1 widgets have integer id
+          before { dashboard.widgets_order = [w3.id.to_i, w2.id.to_i]}
+          # unsorted widgets at the end
+          it { is_expected.to eq([w3, w2, w1])}
+        end
+      end
     end
 
     describe '#filtered_widgets_templates' do


### PR DESCRIPTION
Since ids are Integer on APIv1 and String on APIv2, this causes the
Dashboard#sorted_widgets to create on APIV2 for dashboards created and
sorted on APIv1.