### PR TITLE
[MNOE-1020] Pagination broken

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/products_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/products_controller.rb
@@ -19,7 +19,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::ProductsController
       query = MnoEnterprise::Product.apply_query_params(params)
       query = query.includes(params[:includes]) if params[:includes]
       query = query.includes(DEPENDENCIES) unless params[:skip_dependencies]
-      @products = MnoEnterprise::Product.fetch_all(query)
+
+      # Paginate if requested, otherwise return all the records, as opposed to the default 25.
+      @products = params[:limit] && params[:offset] ? query.to_a : MnoEnterprise::Product.fetch_all(query)
       response.headers['X-Total-Count'] = query.meta.record_count
     end
   end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/products_controller.rb
@@ -14,7 +14,9 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::ProductsController
     if params[:organization_id] && parent_organization
       query = query.with_params(_metadata: { organization_id: parent_organization.id })
     end
-    @products = MnoEnterprise::Product.fetch_all(query)
+
+    # Paginate if requested, otherwise return all the records, as opposed to the default 25.
+    @products = params[:limit] && params[:offset] ? query.to_a : MnoEnterprise::Product.fetch_all(query)
     response.headers['X-Total-Count'] = query.meta.record_count
   end
 


### PR DESCRIPTION
@BrunoChauvet @ouranos @adamaziz15 

This was changed in https://github.com/maestrano/mno-enterprise/commit/4046ddf2ca5ed55c5d22accb3fa792af6befb50c and I'm a bit confused as to why; is there a corresponding issue I could look at?  

When using #fetch_all it ignores pagination (expected behavior I assume). 

I'm a bit confused as to the purpose of the fetch_all method, because I did some testing and changing it to '.to_a' returns all the records when not given pagination parameters, but I think I'm missing something. 