### PR TITLE
[MNOE-970] Create Nex Job to check if restart is done

### DIFF
--- a/api/app/controllers/mno_enterprise/config_controller.rb
+++ b/api/app/controllers/mno_enterprise/config_controller.rb
@@ -11,6 +11,7 @@ module MnoEnterprise
 
       respond_to do |format|
         format.js { self.response_body = minify(render_to_string) }
+        format.json { render json: Settings.config_timestamp }
       end
     end
 

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
@@ -10,9 +10,10 @@ module MnoEnterprise
 
     # PATCH /mnoe/jpi/v1/admin/tenant
     def update
+      timestamp = Time.current.to_i
+      params[:tenant].deep_merge!(frontend_config: { config_timestamp: timestamp })
+
       @tenant = MnoEnterprise::Tenant.show
-      timestamp = Time.now.utc.to_i
-      tenant_params['frontend_config']&.merge!(config_timestamp: timestamp)
       @tenant.update_attributes!(tenant_params)
 
       MnoEnterprise::SystemManager.restart(timestamp)

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/tenants_controller.rb
@@ -11,10 +11,18 @@ module MnoEnterprise
     # PATCH /mnoe/jpi/v1/admin/tenant
     def update
       @tenant = MnoEnterprise::Tenant.show
+      timestamp = Time.now.utc.to_i
+      tenant_params['frontend_config']&.merge!(config_timestamp: timestamp)
       @tenant.update_attributes!(tenant_params)
 
-      MnoEnterprise::SystemManager.restart
+      MnoEnterprise::SystemManager.restart(timestamp)
       render :show
+    end
+
+    # GET /mnoe/jpi/v1/admin/tenant/restart_status
+    def restart_status
+      status = MnoEnterprise::SystemManager.restart_status
+      render json: { status: status }
     end
 
     # PATCH /mnoe/jpi/v1/admin/tenant/domain

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -311,6 +311,7 @@ MnoEnterprise::Engine.routes.draw do
 
         resource 'tenant', only: [:show, :update] do
           member do
+            get :restart_status
             post :ssl_certificates, action: :add_certificates
             match :domain, action: :update_domain, via: [:put, :patch]
           end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/tenants_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/tenants_controller_spec.rb
@@ -64,6 +64,18 @@ module MnoEnterprise
       end
     end
 
+    describe 'GET #restart_status' do
+      let(:tenant_params) { {frontend_config: {}} }
+
+      subject { get :restart_status }
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'gets the restart status' do
+        expect(MnoEnterprise::SystemManager).to receive(:restart_status)
+        subject
+      end
+    end
+
     describe 'PATCH #update_domain' do
       let(:tenant_params) { {domain: 'foo.test'} }
 

--- a/api/spec/requests/mnoe/jpi/v1/admin/tenants_spec.rb
+++ b/api/spec/requests/mnoe/jpi/v1/admin/tenants_spec.rb
@@ -7,6 +7,7 @@ module MnoEnterprise
     render_views
 
     before { stub_audit_events }
+    before { Timecop.freeze(Date.parse('2015-02-15')) }
 
     let(:tenant) { build(:tenant,  domain: 'tenant.domain.test')}
     let(:user) { build(:user, :admin, mnoe_tenant: tenant) }
@@ -31,7 +32,7 @@ module MnoEnterprise
       end
 
       describe 'deep_munge' do
-        let(:tenant_params) { {frontend_config: {foo: {bar: []}}} }
+        let(:tenant_params) { { frontend_config: {foo: {bar: []}, config_timestamp: Time.now.to_i } } }
 
         it 'does not munge the frontend config' do
           allow(MnoEnterprise::Tenant).to receive(:show).and_return(tenant)

--- a/core/lib/mno_enterprise/platform_adapters/adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/adapter.rb
@@ -6,7 +6,12 @@ module MnoEnterprise
     class Adapter
       class << self
         # Restart the MnoEnterprise App
-        def restart
+        def restart(timestamp = nil)
+          raise NotImplementedError
+        end
+
+        # Check if the app restart has finished
+        def restart_status
           raise NotImplementedError
         end
 

--- a/core/lib/mno_enterprise/platform_adapters/local_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/local_adapter.rb
@@ -9,7 +9,7 @@ module MnoEnterprise
           FileUtils.touch('tmp/restart.txt')
         end
 
-        # @see MnoEnterprise::PlatformAdapters::Adapter#restart_done?
+        # @see MnoEnterprise::PlatformAdapters::Adapter#restart_status
         def restart_status
           'success'
         end

--- a/core/lib/mno_enterprise/platform_adapters/local_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/local_adapter.rb
@@ -5,8 +5,13 @@ module MnoEnterprise
     class LocalAdapter < Adapter
       class << self
         # @see MnoEnterprise::PlatformAdapters::Adapter#restart
-        def restart
+        def restart(timestamp = nil)
           FileUtils.touch('tmp/restart.txt')
+        end
+
+        # @see MnoEnterprise::PlatformAdapters::Adapter#restart_done?
+        def restart_status
+          'success'
         end
 
         # @see MnoEnterprise::PlatformAdapters::Adapter#publish_assets

--- a/core/lib/mno_enterprise/platform_adapters/nex_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/nex_adapter.rb
@@ -34,23 +34,21 @@ module MnoEnterprise
 
         # @see MnoEnterprise::PlatformAdapters::Adapter#restart
         def restart(timestamp = nil)
-          # TODO: implement using nex_client
-          # For now this work with one node
+          return FileUtils.touch('tmp/restart.txt') unless timestamp
 
-          # Restart myself
-          # nex_app.restart
-          # puts "success" unless nex_app.errors.any?
-
-          cmd = "touch tmp/restart.txt && " \
-            "timestamp=0 && " \
-            "while [ $timestamp -ne #{timestamp} ]; " \
-            "do aux=$(echo `curl -s -X GET http://localhost/mnoe/config.json`) && " \
-            "timestamp=${aux:-0}; done"
+          cmd = <<~CMD.squish
+            touch tmp/restart.txt &&
+            timestamp=0 &&
+            while [ $timestamp -ne #{timestamp} ];
+            do aux=$(echo `curl -s -X GET http://localhost/mnoe/config.json`) &&
+            timestamp=${aux:-0} &&
+            sleep 1; done
+          CMD
           c = NexClient::ExecCmd.new(
             name: "check restart timestamp",
             script: cmd,
             local: true,
-            parallel: true
+            parallel: false
           )
           c.relationships.executor = nex_app
           c.save

--- a/core/lib/mno_enterprise/platform_adapters/nex_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/nex_adapter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-gem 'nex_client', '~> 0.17.0'
+gem 'nex_client', '~> 0.16.0'
 require 'nex_client'
 require 'rake'
 

--- a/core/lib/mno_enterprise/platform_adapters/nex_cluster_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/nex_cluster_adapter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module MnoEnterprise
+  module PlatformAdapters
+    # Nex!™ Adapter for MnoEnterprise::PlatformClient when app has more than one node
+    # The Nex!™ docker image provide `awscli` and a Minio storage addon
+    class NexClusterAdapter < NexAdapter
+      class << self
+        # @see MnoEnterprise::PlatformAdapters::Adapter#restart
+        def restart(timestamp = nil)
+          return FileUtils.touch('tmp/restart.txt') unless timestamp
+
+          cmd = <<~CMD.squish
+            touch tmp/restart.txt &&
+            timestamp=0 &&
+            while [ $timestamp -ne #{timestamp} ];
+            do aux=$(echo `curl -s -X GET http://localhost/mnoe/config.json`) &&
+            timestamp=${aux:-0} &&
+            sleep 1; done
+          CMD
+          c = NexClient::ExecCmd.new(
+            name: "check restart timestamp",
+            script: cmd,
+            local: true,
+            parallel: false
+          )
+          c.relationships.executor = nex_app
+          c.save
+
+          c.execute
+
+          Rails.cache.write("exec_cmd_id", c.id)
+        end
+
+        def restart_status
+          setup_nex_client
+          # TODO: Need to adapt depending on the cache_store
+          cmd_id = Rails.cache.fetch("exec_cmd_id")
+          cmd = NexClient::ExecCmd.select(:status).find(cmd_id).first
+          cmd.status
+        end
+      end
+    end
+  end
+end

--- a/core/lib/mno_enterprise/platform_adapters/test_adapter.rb
+++ b/core/lib/mno_enterprise/platform_adapters/test_adapter.rb
@@ -6,7 +6,11 @@ module MnoEnterprise
     class TestAdapter < Adapter
       class << self
         # @see MnoEnterprise::PlatformAdapters::Adapter#restart
-        def restart
+        def restart(timestamp = nil)
+        end
+
+        def restart_status
+          'success'
         end
 
         # @see MnoEnterprise::PlatformAdapters::Adapter#publish_assets

--- a/core/lib/mno_enterprise/system_manager.rb
+++ b/core/lib/mno_enterprise/system_manager.rb
@@ -19,6 +19,9 @@ module MnoEnterprise
       # @see MnoEnterprise::PlatformAdapters::Adapter#restart
       delegate :restart, to: :adapter
 
+      # @see MnoEnterprise::PlatformAdapters::Adapter#restart_done?
+      delegate :restart_status, to: :adapter
+
       # @see MnoEnterprise::PlatformAdapters::Adapter#clear_assets
       delegate :clear_assets, to: :adapter
 

--- a/core/mno-enterprise-core.gemspec
+++ b/core/mno-enterprise-core.gemspec
@@ -58,5 +58,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sparkpost', '~> 0.1.4'
 
   # Platform
-  s.add_development_dependency 'nex_client', '~> 0.16.0'
+  s.add_development_dependency 'nex_client', '~> 0.17.0'
 end

--- a/core/mno-enterprise-core.gemspec
+++ b/core/mno-enterprise-core.gemspec
@@ -58,5 +58,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sparkpost', '~> 0.1.4'
 
   # Platform
-  s.add_development_dependency 'nex_client', '~> 0.17.0'
+  s.add_development_dependency 'nex_client', '~> 0.16.0'
 end

--- a/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
+++ b/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
@@ -86,15 +86,7 @@ describe MnoEnterprise::PlatformAdapters::NexAdapter do
     end
 
     describe '.restart' do
-      subject { described_class.restart(Time.current.to_i) }
-      let(:exec_cmd) { NexClient::ExecCmd.new(id: 1) }
-      before { allow(NexClient::ExecCmd).to receive(:new).and_return(exec_cmd) }
-      before { allow(exec_cmd).to receive_messages(:save => exec_cmd, :execute => true) }
-
-      it 'creates a script to check to restart status' do
-        expect(exec_cmd).to receive(:execute)
-        subject
-      end
+      it 'restarts the app'
     end
 
     describe '.update_domain' do

--- a/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
+++ b/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
@@ -25,10 +25,6 @@ describe MnoEnterprise::PlatformAdapters::NexAdapter do
     end
   end
 
-  describe '.restart' do
-    it 'restarts the app'
-  end
-
   context 'Assets Operation' do
     let(:aws_cmd) { "AWS_ACCESS_KEY_ID=${MINIO_ACCESS_KEY} AWS_SECRET_ACCESS_KEY=${MINIO_SECRET_KEY} aws --endpoint-url ${MINIO_URL}" }
     let(:logo_file) { Rails.root.join('app', 'assets', 'images', 'mno_enterprise', 'main-logo.png') }
@@ -90,11 +86,10 @@ describe MnoEnterprise::PlatformAdapters::NexAdapter do
     end
 
     describe '.restart' do
-      subject { described_class.restart }
+      subject { described_class.restart(Time.current.to_i) }
       let(:exec_cmd) { NexClient::ExecCmd.new(id: 1) }
       before { allow(NexClient::ExecCmd).to receive(:new).and_return(exec_cmd) }
       before { allow(exec_cmd).to receive_messages(:save => exec_cmd, :execute => true) }
-      before { allow(FileUtils).to receive(:touch) }
 
       it 'creates a script to check to restart status' do
         expect(exec_cmd).to receive(:execute)

--- a/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
+++ b/core/spec/lib/mno_enterprise/platform_adapters/nex_adapter_spec.rb
@@ -89,6 +89,18 @@ describe MnoEnterprise::PlatformAdapters::NexAdapter do
       allow(NexClient::App).to receive(:find).with('nex-app-id').and_return([nex_app])
     end
 
+    describe '.restart' do
+      subject { described_class.restart }
+      let(:exec_cmd) { NexClient::ExecCmd.new(id: 1) }
+      before { allow(NexClient::ExecCmd).to receive(:new).and_return(exec_cmd) }
+      before { allow(exec_cmd).to receive_messages(:save => exec_cmd, :execute => true) }
+      before { allow(FileUtils).to receive(:touch) }
+
+      it 'creates a script to check to restart status' do
+        expect(exec_cmd).to receive(:execute)
+        subject
+      end
+    end
 
     describe '.update_domain' do
       before  { allow_any_instance_of(NexClient::Domain).to receive(:save).and_return(true) }

--- a/core/spec/lib/mno_enterprise/platform_adapters/nex_cluster_adapter_spec.rb
+++ b/core/spec/lib/mno_enterprise/platform_adapters/nex_cluster_adapter_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe MnoEnterprise::PlatformAdapters::NexClusterAdapter do
+  include MnoEnterprise::TestingSupport::SharedExamples::PlatformAdapter
+
+  it_behaves_like MnoEnterprise::PlatformAdapters::Adapter
+
+  describe '.restart' do
+    subject { described_class.restart(Time.current.to_i) }
+    let(:exec_cmd) { NexClient::ExecCmd.new(id: 1) }
+    before { allow(NexClient::ExecCmd).to receive(:new).and_return(exec_cmd) }
+    before { allow(exec_cmd).to receive_messages(:save => exec_cmd, :execute => true) }
+
+    xit 'creates a script to check to restart status' do
+      expect(exec_cmd).to receive(:execute)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
- When tenant config is updated, create a job on the Nex app to check the config_timestamp.

(Build fails for now. Once PR on nex_client is merged and new version is tagged, will need to update the gem)