### PR TITLE
[MNOE-1036] Error occurs when adding members to team

### DIFF
--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/teams_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/teams_controller.rb
@@ -45,6 +45,7 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::TeamsController
       MnoEnterprise::EventLogger.info('team_apps_update', current_user.id, 'Team apps updated', @team,
                                       {apps: list.map{|l| l['name']}})
     end
+    @team = @team.load_required(:organization, :users, :app_instances)
     render 'show'
   end
 


### PR DESCRIPTION
This error happens only when adding app to team or change team name, 
this PR is on the backend to  load association when team is updated
on the front end a seperate PR has been raised to mno-enterprise-angular(https://github.com/maestrano/mno-enterprise-angular/pull/481)
