### PR TITLE
[MNOE-1213] Clear staff clients when updating to admin

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
@@ -63,6 +63,7 @@ module MnoEnterprise
       return render_not_found('User') unless @user
       @user.attributes = user_update_params
       update_sub_tenant(@user)
+      clear_clients(@user)
       @user.save!
       @user = @user.load_required(:sub_tenant)
       render :show
@@ -132,6 +133,13 @@ module MnoEnterprise
         attrs.merge!(orga_on_create: true, company: 'Demo Company', demo_account: 'Staff demo company')
       end
       attrs
+    end
+
+    def clear_clients(user)
+      # if the user is updated to admin or division admin, their clients are cleared
+      if user_update_params[:admin_role] && user_update_params[:admin_role] != 'staff'
+        user.clear_clients!
+      end
     end
 
     def update_sub_tenant(user)

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -165,6 +165,11 @@ module MnoEnterprise
       process_custom_result(result)
     end
 
+    def clear_clients!
+      result = update_clients({data: {attributes: {set: []}}})
+      process_custom_result(result)
+    end
+
     # Find a user using a confirmation token
     def self.find_for_confirmation(confirmation_token)
       original_token = confirmation_token

--- a/core/spec/models/mno_enterprise/user_spec.rb
+++ b/core/spec/models/mno_enterprise/user_spec.rb
@@ -372,5 +372,30 @@ module MnoEnterprise
         end
       end
     end
+
+    describe '#clear_clients!' do
+      subject { user.clear_clients! }
+
+      let(:user) { build(:user) }
+      let!(:stub) { stub_api_v2(:patch, "/users/#{user.id}/update_clients", [], [], {}, {data: {attributes: {set: []}}})}
+
+      it 'clears the clients' do
+        subject
+        expect(stub).to have_been_requested
+      end
+    end
+
+    describe '#update_clients!' do
+      subject { user.update_clients!(params) }
+
+      let(:params) { {data: {attributes: {add: [1, 2]}}} }
+      let(:user) { build(:user) }
+      let!(:stub) { stub_api_v2(:patch, "/users/#{user.id}/update_clients", [], [], {}, params)}
+
+      it 'updates the clients' do
+        subject
+        expect(stub).to have_been_requested
+      end
+    end
   end
 end


### PR DESCRIPTION
Backporting [code from 3.3](https://github.com/maestrano/mno-enterprise/blob/master/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb#L93-L96)