### PR TITLE
[MNOE-1194] order status change notification emails

### DIFF
--- a/api/app/controllers/mno_enterprise/webhook/mnohub/receive_controller.rb
+++ b/api/app/controllers/mno_enterprise/webhook/mnohub/receive_controller.rb
@@ -1,0 +1,6 @@
+module MnoEnterprise
+  class Webhook::Mnohub::ReceiveController < ApplicationController
+    include MnoEnterprise::Concerns::Controllers::Webhook::Mnohub::ReceiveController
+    # You can easily overwrite/extend this concern by inserting the code here
+  end
+end

--- a/api/app/jobs/mno_enterprise/system_events_processor_job.rb
+++ b/api/app/jobs/mno_enterprise/system_events_processor_job.rb
@@ -1,0 +1,9 @@
+module MnoEnterprise
+  class SystemEventsProcessorJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(*args)
+      MnoEnterprise::SystemEventsProcessor.process
+    end
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -94,6 +94,9 @@ MnoEnterprise::Engine.routes.draw do
       end
     end
     # Maestrano-hub events
+    namespace :mnohub do 
+      resources :receive, only: [:create]
+    end
     resources :events, only: [:create]
   end
 

--- a/api/lib/mno_enterprise/concerns/controllers/webhook/mnohub/receive_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/webhook/mnohub/receive_controller.rb
@@ -1,0 +1,10 @@
+module MnoEnterprise::Concerns::Controllers::Webhook::Mnohub::ReceiveController
+  extend ActiveSupport::Concern
+  #==================================================================
+  # Instance methods
+  #==================================================================
+  # POST /mnoe/webhook/mnohub/receive
+  def create
+    MnoEnterprise::SystemEventsProcessorJob.perform_later
+  end
+end

--- a/api/lib/mno_enterprise/system_events_processor.rb
+++ b/api/lib/mno_enterprise/system_events_processor.rb
@@ -1,0 +1,12 @@
+module MnoEnterprise
+  class SystemEventsProcessor
+    
+    def self.process
+      MnoEnterprise::SystemEvent.fetch_all.each do |system_event|
+        next if system_event.event != 'order_status_change' &&
+                system_event.resource_type != "subscription_events"
+        MnoEnterprise::SystemNotificationMailer.order_status_changed(system_event.id).deliver_later
+      end
+    end
+  end
+end

--- a/core/app/models/mno_enterprise/system_event.rb
+++ b/core/app/models/mno_enterprise/system_event.rb
@@ -1,0 +1,11 @@
+module MnoEnterprise
+  class SystemEvent < BaseResource
+    property :created_at, type: :time
+    property :updated_at, type: :time
+    property :event, type: :string
+    property :from
+    property :to
+    property :resource_type, type: :string
+    property :resource_id, type: :string
+  end
+end

--- a/core/app/views/system_notifications/order-status-changed.html.erb
+++ b/core/app/views/system_notifications/order-status-changed.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <%= stylesheet_link_tag('mno_enterprise/mail.css') %>
+  </head>
+  <body>
+    <p class="header">
+      <%= image_tag(main_logo_white_bg_path, main_logo_white_bg_size_to_fit) %>
+    </p>
+
+    <p>Hi there,</p>
+    <p>
+      <%= @info[:first_name] %>, Order status of this customer has changed to <%= @info[:subscription_status] %>, which is associated to this product <%= @info[:product_name] %> and its subscription id is <%= @info[:subscription_id] %>.
+    </p>
+
+    <p>
+      You can find subscription here.
+      <a href="<%= @info[:subscription_link] %>">Subscription Link</a>
+    </p>
+
+    <p>
+       Regards,<br/>
+       The Marketplace team
+    </p>
+
+    <p class="footer">
+      <%= @info[:company] %>
+    </p>
+  </body>
+</html>

--- a/core/app/views/system_notifications/order-status-changed.text.erb
+++ b/core/app/views/system_notifications/order-status-changed.text.erb
@@ -1,0 +1,10 @@
+Hi there,
+=================================================================
+
+<%= @info[:first_name] %>, Order status of this customer has changed to <%= @info[:subscription_status] %>, which is associated to this product <%= @info[:product_name] %> and its subscription id is <%= @info[:subscription_id] %>.
+
+You can find subscription here.
+<%= @info[:subscription_link] %>
+
+Regards,
+The Marketplace team

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -65,7 +65,7 @@ module MnoEnterprise::Concerns::Models::Organization
       else
         invite.status == 'staged'
       end
-    end
+    end unless self.orga_invites.blank?
     [self.users, invites.to_a].flatten
   end
 


### PR DESCRIPTION
hey @ouranos , I have added a controller and endpoint to fetch all the system_events.
 I assumed the controller here named as `MnoEnterprise :: Concerns :: Controllers :: Webhook :: Mnohub :: ReceiveController`  and Created **SystemEventProcessor** which includes logic of sending email for only 'subscription_events'.
I have created mailer_action order_status_changed into system_notification_mailer.
For the notification_on_#{System_event_status} logic, I have assumed that MnoEnterprise :: Product webhook will have the three methods like notification_on_success, notification_on_failure and notification_on_approval. And system_event also have status like success, failure and approval.
 please have a look and let me know your valuable feedback