### PR TITLE
[OPALSUP-257]Add team member error

### DIFF
--- a/api/app/views/mno_enterprise/jpi/v1/teams/_team.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/teams/_team.json.jbuilder
@@ -10,6 +10,6 @@ end
 json.app_instances do
   json.array! team.app_instances do |instance|
     json.extract! instance, :id, :name
-    json.logo instance.app.logo
+    json.logo instance.app.logo if instance.app
   end
 end


### PR DESCRIPTION
on the Company/Team page, error happens when adding apps on the team and save, BEFORE adding members to this team. the API call to mno-enterprise Teams controller gets correct response, error happens at render html partial because `instance.app` could be nil