### PR TITLE
[MNOE-1266] Change of Maestrano name in the content

### DIFF
--- a/core/app/models/mno_enterprise/app.rb
+++ b/core/app/models/mno_enterprise/app.rb
@@ -61,7 +61,7 @@ module MnoEnterprise
     # Sanitize the app description
     # E.g.: replace any mention of Maestrano by the tenant name
     def sanitized_description
-      @sanitized_description ||= (self.description || '').gsub(/(?!cdn\.)maestrano(?!\.com)/i,MnoEnterprise.app_name)
+      @sanitized_description ||= (self.description || '').gsub(/(?<!cdn\.)(?<!cdn-prd-)maestrano(?!\.com)/i,MnoEnterprise.app_name)
     end
 
     # Methods for appinfo flags

--- a/core/spec/models/mno_enterprise/app_spec.rb
+++ b/core/spec/models/mno_enterprise/app_spec.rb
@@ -41,6 +41,11 @@ module MnoEnterprise
         app.description = 'Screenshot: <img src="//cdn.maestrano.com/web/mno/screenshot.png"/>'
         expect(app.sanitized_description).to eq(app.description)
       end
+
+      it 'does not replace for bucket name cdn-prd-maestrano' do
+        app.description = '<a href="https://s3.amazonaws.com/cdn-prd-maestrano/somefile" target="_blank">report</a>'
+        expect(app.sanitized_description).to eq(app.description)
+      end
     end
 
     describe '#regenerate_api_key!' do


### PR DESCRIPTION
update sanitized description to not replace for bucket name cdn-prd-maestrano