### PR TITLE
[OPALSUP-343] Invoice contact details

### DIFF
--- a/core/config/initializers/00_tenant_config_schema.rb
+++ b/core/config/initializers/00_tenant_config_schema.rb
@@ -324,6 +324,7 @@ MnoEnterprise::CONFIG_JSON_SCHEMA = {
                 },
                 invoice_contact_details: {
                   type: "string",
+                  maxLength: 100,
                   title: "Invoice Contact Details",
                   description: "Let your customer know who to contact for invoice support.",
                   default: ""


### PR DESCRIPTION
Add max length constraint to invoice contact details to only allow
contact details to take up one line on invoice pdf.