### PR TITLE
[MARLIN-511] dashboards not showing

### DIFF
--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_kpi.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_kpi.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! kpi, :id, :name, :created_at, :updated_at, :settings
+json.extract! kpi, :id, :endpoint, :created_at, :updated_at, :settings


### PR DESCRIPTION
Kpi does not have a name attribute -- causes 500 error. 

Contingent on: https://github.com/maestrano/mnoe-admin-panel/pull/349