### PR TITLE
[MACAWSUP-43] 2fa for admin users

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -66,8 +66,10 @@ MnoEnterprise::Engine.routes.draw do
     get "/auth/users/confirmation/lounge", to: "auth/confirmations#lounge", as: :user_confirmation_lounge
     patch "/auth/users/confirmation/finalize", to: "auth/confirmations#finalize", as: :user_confirmation_finalize
     patch "/auth/users/confirmation", to: "auth/confirmations#update"
-    two_factor_enabled = Settings.authentication.two_factor.admin_enabled || Settings.authentication.two_factor.users_enabled
-    post "auth/users/sessions/verify_otp", to: "auth/sessions#verify_otp" if two_factor_enabled
+
+    if Settings&.authentication&.two_factor&.admin_enabled || Settings&.authentication&.two_factor&.users_enabled
+        post "auth/users/sessions/verify_otp", to: "auth/sessions#verify_otp"
+    end
 
     # Patch omniauth routes as per plataformatec/devise#2692
     providers = Regexp.union(Devise.omniauth_providers.map(&:to_s))

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -66,6 +66,8 @@ MnoEnterprise::Engine.routes.draw do
     get "/auth/users/confirmation/lounge", to: "auth/confirmations#lounge", as: :user_confirmation_lounge
     patch "/auth/users/confirmation/finalize", to: "auth/confirmations#finalize", as: :user_confirmation_finalize
     patch "/auth/users/confirmation", to: "auth/confirmations#update"
+    two_factor_enabled = Settings.authentication.two_factor.admin_enabled || Settings.authentication.two_factor.users_enabled
+    post "auth/users/sessions/verify_otp", to: "auth/sessions#verify_otp" if two_factor_enabled
 
     # Patch omniauth routes as per plataformatec/devise#2692
     providers = Regexp.union(Devise.omniauth_providers.map(&:to_s))

--- a/api/spec/controllers/mno_enterprise/auth/sessions_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/auth/sessions_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+# Specs for Sessions Controller
+module MnoEnterprise
+  # Auth module
+  module Auth
+    describe SessionsController, type: :controller do
+      routes { MnoEnterprise::Engine.routes }
+      # bypass devise router
+      before { request.env['devise.mapping'] = Devise.mappings[:user] }
+      let(:user) { build(:user) }
+
+      describe '#create' do
+        before do
+          allow(request.env['warden'])
+            .to receive(:authenticate!).and_return(user)
+        end
+
+        it 'checks if user requires otp for login' do
+          expect(user).to receive(:requires_otp_for_login?)
+          post :create
+        end
+
+        it "doesn't activates otp when user doesnt' require otp for login" do
+          allow(user).to receive(:requires_otp_for_login?) { false }
+          expect(user).to_not receive(:activate_otp)
+          post :create
+        end
+
+        it 'signs in the user' do
+          post :create
+          expect(controller.current_user).to be user
+        end
+
+        context 'when user requires otp for login' do
+          before do
+            allow(user).to receive(:requires_otp_for_login?) { true }
+            allow(user).to receive(:activate_otp)
+          end
+
+          it 'does not sign in the user' do
+            post :create
+            expect(controller.current_user).to be nil
+          end
+
+          it 'activates otp' do
+            expect(user).to receive(:activate_otp)
+            post :create
+          end
+
+          context 'when user has an unconfirmed otp_secret' do
+            before do
+              user.unconfirmed_otp_secret = 'unconfirmed otp secret'
+            end
+
+            it "sets a quick response code into the user's attributes" do
+              allow(user).to receive(:activate_otp)
+              expect(user).to receive(:set_quick_response_code_in_attributes)
+              post :create
+            end
+          end
+        end
+      end
+
+      describe 'POST #verify_otp' do
+        let(:params) do
+          { user_id: '1', otp_attempt: '2' }
+        end
+
+        before do
+          Settings.authentication.two_factor.admin_enabled = true
+          Rails.application.reload_routes!
+          allow(MnoEnterprise::User).to receive(:find) { [user] }
+        end
+
+        it 'validates otp attempt for specified user' do
+          expect(MnoEnterprise::User)
+            .to receive(:find).with(id: params[:user_id])
+          expect(user)
+            .to receive(:validate_and_consume_otp!).with(params[:otp_attempt])
+          post :verify_otp, params
+        end
+
+        it 'signs in the user when otp attempt is valid' do
+          allow(user)
+            .to receive(:validate_and_consume_otp!) { true }
+          post :verify_otp
+          expect(controller.current_user).to be user
+        end
+
+        it "doesn't sign in the user when otp attempt is invalid" do
+          allow(user)
+            .to receive(:validate_and_consume_otp!) { false }
+          post :verify_otp
+          expect(controller.current_user).to be nil
+        end
+      end
+    end
+  end
+end

--- a/api/spec/routing/devise/sessions_routing_spec.rb
+++ b/api/spec/routing/devise/sessions_routing_spec.rb
@@ -15,6 +15,26 @@ module MnoEnterprise
     it 'routes to #destroy' do
       expect(delete('/auth/users/sign_out')).to route_to("mno_enterprise/auth/sessions#destroy")
     end
+
+    describe 'route to verify_otp' do
+      it "doesn't route to #verify_otp when 2fa isn't enabled" do
+        expect(post('/auth/users/sessions/verify_otp'))
+          .to_not route_to('mno_enterprise/auth/sessions#verify_otp')
+      end
+      
+      it 'routes to #verify_otp when 2fa enabled for admins' do
+        Settings.authentication.two_factor.admin_enabled = true
+        Rails.application.reload_routes!
+        expect(post('/auth/users/sessions/verify_otp'))
+          .to route_to('mno_enterprise/auth/sessions#verify_otp')
+      end
+
+      it 'routes to #verify_otp when 2fa enabled for users' do
+        Settings.authentication.two_factor.users_enabled = true
+        Rails.application.reload_routes!
+        expect(post('/auth/users/sessions/verify_otp'))
+          .to route_to('mno_enterprise/auth/sessions#verify_otp')
+      end
+    end
   end
 end
-

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -287,9 +287,9 @@ module MnoEnterprise
 
     def requires_otp_for_login?
       if admin?
-        Settings.authentication.two_factor.admin_enabled
+        Settings&.authentication&.two_factor&.admin_enabled
       else
-        Settings.authentication.two_factor.users_enabled
+        Settings&.authentication&.two_factor&.users_enabled
       end
     end
 

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -1,3 +1,5 @@
+require 'rqrcode_png'
+
 module MnoEnterprise
   class User < BaseResource
     include MnoEnterprise::Concerns::Models::IntercomUser
@@ -49,6 +51,9 @@ module MnoEnterprise
     property :geo_currency, type: :string
     property :failed_attempts
     property :password_changed_at
+    # Two factor
+    property :otp_attempt_successful, type: :boolean
+    property :unconfirmed_otp_secret, type: :string
 
     has_one :sub_tenant
 
@@ -278,6 +283,45 @@ module MnoEnterprise
 
     def admin?
       admin_role.to_s.casecmp(ADMIN_ROLE).zero?
+    end
+
+    def requires_otp_for_login?
+      if admin?
+        Settings.authentication.two_factor.admin_enabled
+      else
+        Settings.authentication.two_factor.users_enabled
+      end
+    end
+
+    def activate_otp
+      self.attributes = {
+        otp_required_for_login: true,
+        unconfirmed_otp_secret: nil
+      }
+      save!
+      reload
+    end
+
+    def set_quick_response_code_in_attributes
+      two_factor_url = 'otpauth://totp/'\
+                       "#{Settings.authentication.two_factor.app_id}:"\
+                       "#{email}?"\
+                       "secret=#{unconfirmed_otp_secret}"\
+                       "&issuer=#{Settings.authentication.two_factor.app_name}"
+      qr_code = RQRCode::QRCode.new(two_factor_url)
+                               .to_img
+                               .resize(240, 240)
+                               .to_data_url
+      attributes['quick_response_code'] = qr_code
+    end
+
+    def validate_and_consume_otp!(otp_attempt)
+      self.attributes = {
+        otp_attempt: otp_attempt,
+        otp_attempt_successful: false
+      }
+      save!
+      reload.otp_attempt_successful
     end
   end
 end

--- a/core/config/initializers/00_tenant_config_schema.rb
+++ b/core/config/initializers/00_tenant_config_schema.rb
@@ -704,6 +704,40 @@ MnoEnterprise::CONFIG_JSON_SCHEMA = {
           }
         },
       }
+    },
+    authentication: {
+      title: 'Authentication feature',
+      description: 'Authentication feature',
+      type: 'object',
+      properties: {
+        two_factor: {
+          title: 'Two factor',
+          description: 'Two factor',
+          type: 'object',
+          properties: {
+            admin_enabled: {
+              type: 'boolean',
+              description: 'Enable for admin',
+              default: false
+            },
+            app_id: {
+              type: 'string',
+              description: 'App id to display on the authenticator',
+              default: ''
+            },
+            app_name: {
+              type: 'string',
+              description: 'App name to display on the authenticator',
+              default: ''
+            },
+            users_enabled: {
+              type: 'boolean',
+              description: 'Enable for users',
+              default: false
+            }
+          }
+        }
+      }
     }
   }
 }.with_indifferent_access.freeze

--- a/core/mno-enterprise-core.gemspec
+++ b/core/mno-enterprise-core.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'devise', '~> 3.0'
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'omniauth', '~> 1.8.1'
+  s.add_dependency 'rqrcode_png', '0.1.5'
 
   # Markdown parsing
   s.add_dependency 'redcarpet', '~> 3.3', '>= 3.3.3'


### PR DESCRIPTION
https://maestrano.atlassian.net/browse/MACAWSUP-43

@ouranos | @cesar-tonnoir - I do the quick response code generation here so that the app name and id can be personalised by each enterprise. Generation and validation of otp happens in the back end via attributes and after_save callbacks. 

Hey my travis ci build is failing but I can't figure it out? Have you guys seen this error before? 

**UPDATE: This was because of sqlite3 incompatibility and was fixed recently in a different pull request.**