### PR TITLE
Add dependency constraint on sqlite3

### DIFF
--- a/common_mnoe_dependencies.rb
+++ b/common_mnoe_dependencies.rb
@@ -3,7 +3,8 @@
 # the one component of Mnoe.
 source 'https://rubygems.org'
 
-gem 'sqlite3'
+# sqlite3_adapter requires 1.3.x
+gem 'sqlite3', '~> 1.3.13'
 
 group :test do
   gem 'rspec-rails'


### PR DESCRIPTION
sqlite3 1.4 is conflicting with sqlite3_adapter which requires 1.3.x

See https://github.com/rails/rails/issues/35153

Backporting #805 