### PR TITLE
[KAPP-175] Staff Dashboard

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
@@ -71,10 +71,32 @@ module MnoEnterprise
       head status: :ok
     end
 
+    # Allows to create a dashboard using another dashboard as a source
+    # At the moment, only dashboards of type "template" can be copied
+    # Ultimately we could allow the creation of dashboards from any other dashboard
+    # ---------------------------------
+    # POST mnoe/jpi/v1/admin/impac/dashboards/1/copy
+    def copy
+      render json: { errors: { message: 'Dashboard template not found' } }, status: :not_found unless template
+
+      # Owner is the current user by default, can be overriden to something else (eg: current organization)
+      @dashboard = template.copy(current_user, dashboard_params[:name], dashboard_params[:organization_ids])
+
+      unless @dashboard.present?
+        return render json: { errors: 'Cannot copy template' }, status: :bad_request
+      end
+
+      render :show
+    end
+
     protected
 
     def dashboard
       @dashboard ||= MnoEnterprise::Impac::Dashboard.find(params[:id])
+    end
+
+    def template
+      @template ||= MnoEnterprise::Impac::Dashboard.templates.find(params[:id])
     end
 
     def whitelisted_params

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
@@ -79,10 +79,12 @@ module MnoEnterprise
     protected
 
     def dashboard
-      @dashboard ||= MnoEnterprise::Impac::Dashboard.find(params[:id])
+      # Staff dashboard is scoped to current staff
+      @dashboard ||= MnoEnterprise::Impac::Dashboard.find_by(id: params[:id], owner_type: 'User', owner_id: current_user.id)
     end
 
     def template
+      # Templates are available to all staff
       @template ||= MnoEnterprise::Impac::Dashboard.templates.find(params[:id])
     end
 

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/dashboards_controller.rb
@@ -1,0 +1,94 @@
+module MnoEnterprise
+  # TODO: DRY with dashboard templates?
+  class Jpi::V1::Admin::Impac::DashboardsController < Jpi::V1::Admin::BaseResourceController
+    # GET /mnoe/jpi/v1/admin/impac/dashboards
+    # TODO: filter by org Id in mnoe
+    # TODO: should filter to current_user?
+    # TODO: what happen when more than 30 dhb? => custom scope in MnoHub? with LIKE text search
+    def index
+      # query = MnoEnterprise::Impac::Dashboard
+      #           .apply_query_params(params)
+      #           # .includes(*DASHBOARD_DEPENDENCIES)
+      #
+      # response.headers['X-Total-Count'] = query.meta.record_count
+      #
+      # @dashboards = query.to_a
+
+      data_source = params[:where].delete(:data_sources) if params[:where]
+
+      @dashboards = MnoEnterprise::Impac::Dashboard
+      @dashboards = @dashboards.limit(params[:limit]) if params[:limit]
+      @dashboards = @dashboards.skip(params[:offset]) if params[:offset]
+      @dashboards = @dashboards.order_by(params[:order_by]) if params[:order_by]
+      @dashboards = @dashboards.where(params[:where]) if params[:where]
+      @dashboards = @dashboards.all.fetch
+
+      response.headers['X-Total-Count'] = @dashboards.metadata[:pagination][:count]
+
+      if data_source
+        @dashboards = @dashboards.select { |dhb| dhb.organizations.map(&:id).include?(data_source.to_i) }
+      end
+
+      # @dashboards = current_user.dashboards
+    end
+
+    # POST /mnoe/jpi/v1/admin/impac/dashboard
+    def create
+      @dashboard = MnoEnterprise::Impac::Dashboard.new(dashboard_params)
+
+      # Abort on failure
+      unless @dashboard.save
+        return render json: { errors: dashboard.errors }, status: :bad_request
+      end
+
+      MnoEnterprise::EventLogger.info('dashboard_create', current_user.id, 'Dashboard Creation', @dashboard)
+      render :show
+    end
+
+    # PATCH/PUT /mnoe/jpi/v1/admin/impac/dashboards/1
+    def update
+      return render json: { errors: { message: 'Dashboard not found' } }, status: :not_found unless dashboard
+
+      # Abort on failure
+      unless dashboard.update(dashboard_params)
+        return render json: { errors: dashboard.errors }, status: :bad_request
+      end
+
+      MnoEnterprise::EventLogger.info('dashboard_update', current_user.id, 'Dashboard Update', dashboard)
+      render :show
+    end
+
+    # DELETE /mnoe/jpi/v1/admin/impac/dashboards/1
+    def destroy
+      return render json: { errors: { message: 'Dashboard not found' } }, status: :not_found unless dashboard
+
+      # Abort on failure
+      unless dashboard.destroy
+        return render json: { errors: 'Cannot destroy dashboard' }, status: :bad_request
+      end
+
+      MnoEnterprise::EventLogger.info('dashboard_delete', current_user.id, 'Dashboard Deletion', dashboard)
+      head status: :ok
+    end
+
+    protected
+
+    def dashboard
+      @dashboard ||= MnoEnterprise::Impac::Dashboard.find(params[:id])
+    end
+
+    def whitelisted_params
+      [:name, :currency, { widgets_order: [] }, { organization_ids: [] }]
+    end
+
+    # Allows all metadata attrs to be permitted, and maps it to :settings
+    # for the Her "meta_data" issue.
+    def dashboard_params
+      params.require(:dashboard).permit(*whitelisted_params).tap do |whitelisted|
+        whitelisted[:settings] = params[:dashboard][:metadata] || {}
+      end
+      .except(:metadata)
+      .merge(owner_type: 'User', owner_id: current_user.id)
+    end
+  end
+end

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller.rb
@@ -48,8 +48,8 @@ module MnoEnterprise
     def dashboard
       @dashboard ||= if params[:dashboard_template_id]
                        MnoEnterprise::Impac::Dashboard.templates.find(params[:dashboard_template_id])
-                     elsif  params[:dashboard_id]
-                       MnoEnterprise::Impac::Dashboard.find(params[:dashboard_id])
+                     elsif params[:dashboard_id]
+                       MnoEnterprise::Impac::Dashboard.find_by(id: params[:dashboard_id], owner_type: 'User', owner_id: current_user.id)
                      end
     end
 

--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller.rb
@@ -1,5 +1,6 @@
 module MnoEnterprise
   # From the Admin panel, an admin can:
+  # - add widgets to staff dashboards (passing the dashboard id)
   # - add widgets to template dashboards (passing the dashboard template id)
   # - update any widget (passing its id)
   # - delete any widget (passing its id)
@@ -8,14 +9,12 @@ module MnoEnterprise
     # POST /mnoe/jpi/v1/admin/impac/dashboard_templates/:id/widgets
     # POST /mnoe/jpi/v1/admin/impac/dashboards/:id/widgets
     def create
-      # TODO: dynamic message
-      return render json: { errors: { message: 'Dashboard template not found' } }, status: :not_found unless dashboard.present?
+      return render json: { errors: { message: "#{container} not found" } }, status: :not_found unless dashboard.present?
 
       @widget = dashboard.widgets.create(widget_create_params)
       return render json: { errors: (widget && widget.errors).to_a }, status: :bad_request unless widget.present? && widget.valid?
 
-      # TODO: dynamic message
-      MnoEnterprise::EventLogger.info('widget_create', current_user.id, 'Template Widget Creation', widget)
+      MnoEnterprise::EventLogger.info('widget_create', current_user.id, "#{container} Widget Creation", widget)
       @no_content = true
       render 'show'
     end
@@ -26,8 +25,7 @@ module MnoEnterprise
         return render json: { errors: 'Cannot update widget' }, status: :bad_request
       end
 
-      # TODO: dynamic?
-      MnoEnterprise::EventLogger.info('widget_update', current_user.id, 'Template Widget Update', widget)
+      MnoEnterprise::EventLogger.info('widget_update', current_user.id, "#{container} Widget Update", widget)
       @nocontent = !params['metadata']
       render 'show'
     end
@@ -38,8 +36,7 @@ module MnoEnterprise
         return render json: { errors: 'Cannot delete widget' }, status: :bad_request
       end
 
-      # TODO: dynamic?
-      MnoEnterprise::EventLogger.info('widget_delete', current_user.id, 'Template Widget Deletion', widget)
+      MnoEnterprise::EventLogger.info('widget_delete', current_user.id, "#{container} Widget Deletion", widget)
       head status: :ok
     end
 
@@ -53,9 +50,10 @@ module MnoEnterprise
                      end
     end
 
-    # def template
-    #   MnoEnterprise::Impac::Dashboard.templates.find(params[:dashboard_template_id].to_i)
-    # end
+    # Used to customise the error message
+    def container
+      params[:dashboard_template_id] ? 'Dashboard template' : 'Dashboard'
+    end
 
     def widget
       @widget ||= MnoEnterprise::Impac::Widget.find(params[:id].to_i)

--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_dashboard.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_dashboard.json.jbuilder
@@ -1,0 +1,25 @@
+json.extract! dashboard, :id, :name, :full_name, :currency
+
+json.metadata dashboard.settings
+
+# :created_at, :updated_at, :settings
+
+json.data_sources dashboard.organizations.map do |org|
+  json.id org.id
+  json.uid org.uid
+  json.label org.name
+end
+
+# TODO: use if nested?
+json.widgets dashboard.widgets, partial: 'mno_enterprise/jpi/v1/admin/impac/widgets/widget', as: :widget
+
+# json.kpis dashboard.kpis, partial: 'mno_enterprise/jpi/v1/impac/kpis/kpi', as: :kpi
+# json.widgets dashboard.widgets, partial: 'mno_enterprise/jpi/v1/impac/widgets/widget', as: :widget
+# json.widgets_templates dashboard.filtered_widgets_templates
+
+# json.kpis template.kpis, partial: 'mno_enterprise/jpi/v1/admin/impac/kpis/kpi', as: :kpi
+# json.widgets template.widgets, partial: 'mno_enterprise/jpi/v1/admin/impac/widgets/widget', as: :widget
+#
+# json.created_at template.created_at
+# json.updated_at template.updated_at
+# json.published template.published

--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_dashboard.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/_dashboard.json.jbuilder
@@ -2,24 +2,11 @@ json.extract! dashboard, :id, :name, :full_name, :currency
 
 json.metadata dashboard.settings
 
-# :created_at, :updated_at, :settings
-
 json.data_sources dashboard.organizations.map do |org|
   json.id org.id
   json.uid org.uid
   json.label org.name
 end
 
-# TODO: use if nested?
+json.kpis dashboard.kpis, partial: 'mno_enterprise/jpi/v1/admin/impac/kpis/kpi', as: :kpi
 json.widgets dashboard.widgets, partial: 'mno_enterprise/jpi/v1/admin/impac/widgets/widget', as: :widget
-
-# json.kpis dashboard.kpis, partial: 'mno_enterprise/jpi/v1/impac/kpis/kpi', as: :kpi
-# json.widgets dashboard.widgets, partial: 'mno_enterprise/jpi/v1/impac/widgets/widget', as: :widget
-# json.widgets_templates dashboard.filtered_widgets_templates
-
-# json.kpis template.kpis, partial: 'mno_enterprise/jpi/v1/admin/impac/kpis/kpi', as: :kpi
-# json.widgets template.widgets, partial: 'mno_enterprise/jpi/v1/admin/impac/widgets/widget', as: :widget
-#
-# json.created_at template.created_at
-# json.updated_at template.updated_at
-# json.published template.published

--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/index.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @dashboards, partial: 'dashboard', as: :dashboard

--- a/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/show.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/impac/dashboards/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'dashboard', dashboard: @dashboard

--- a/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_organization.json.jbuilder
+++ b/api/app/views/mno_enterprise/jpi/v1/admin/organizations/_organization.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! organization, :id, :name, :uid, :soa_enabled, :created_at, :account_frozen
+json.extract! organization, :id, :name, :uid, :soa_enabled, :created_at, :account_frozen, :financial_year_end_month

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -223,6 +223,8 @@ MnoEnterprise::Engine.routes.draw do
 
         # Dashboard templates designer
         namespace :impac do
+          post 'dashboards/:id/copy', to: 'dashboards#copy'
+
           # TODO: DRY between both?
           resources :dashboards, only: [:index, :create, :update, :destroy] do
             resources :widgets, shallow: true, only: [:create, :update, :destroy]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -223,6 +223,12 @@ MnoEnterprise::Engine.routes.draw do
 
         # Dashboard templates designer
         namespace :impac do
+          # TODO: DRY between both?
+          # TODO: specs?
+          resources :dashboards, only: [:index, :show, :create, :update, :destroy] do
+            resources :widgets, shallow: true, only: [:create, :update, :destroy]
+            resources :kpis, shallow: true, only: [:create, :update, :destroy]
+          end
           resources :dashboard_templates, only: [:index, :show, :destroy, :update, :create] do
             resources :widgets, shallow: true, only: [:create, :update, :destroy]
             resources :kpis, shallow: true, only: [:create, :update, :destroy]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -224,8 +224,7 @@ MnoEnterprise::Engine.routes.draw do
         # Dashboard templates designer
         namespace :impac do
           # TODO: DRY between both?
-          # TODO: specs?
-          resources :dashboards, only: [:index, :show, :create, :update, :destroy] do
+          resources :dashboards, only: [:index, :create, :update, :destroy] do
             resources :widgets, shallow: true, only: [:create, :update, :destroy]
             resources :kpis, shallow: true, only: [:create, :update, :destroy]
           end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
@@ -177,5 +177,34 @@ module MnoEnterprise
 
       it_behaves_like "a jpi v1 admin action"
     end
+
+    describe 'POST copy' do
+      subject { post :copy, id: template.id, dashboard: dashboard_params }
+
+      let(:template) { build(:impac_dashboard, dashboard_type: 'template') }
+      let(:dashboard_params) do
+        {
+          name: dashboard.name,
+          currency: dashboard.currency,
+          organization_ids: [org.id]
+        }
+      end
+
+      before do
+        api_stub_for(
+          get: "/dashboards/#{template.id}",
+          params: { filter: { 'dashboard_type' => 'template' } },
+          response: from_api(template)
+        )
+        api_stub_for(
+          post: "/dashboards/#{template.id}/copy",
+          response: from_api(dashboard)
+        )
+      end
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+
+      it_behaves_like "a jpi v1 admin action"
+    end
   end
 end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  describe Jpi::V1::Admin::Impac::DashboardsController, type: :controller do
+    # include MnoEnterprise::TestingSupport::JpiV1TestHelper
+    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
+    render_views
+    routes { MnoEnterprise::Engine.routes }
+    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+
+
+    # =============================================================================================================
+    # TODO: DRY
+    # =============================================================================================================
+
+    RSpec.shared_context "#{described_class}: dashboard dependencies stubs" do
+      before do
+        api_stub_for(
+          get: "/organizations?filter[uid.in][]=#{org.uid}",
+          response: from_api([org])
+        )
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}/widgets",
+          response: from_api([widget])
+        )
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}/kpis",
+          response: from_api([d_kpi])
+        )
+        api_stub_for(
+          get: "/widgets/#{widget.id}/kpis",
+          response: from_api([w_kpi])
+        )
+      end
+    end
+
+    let(:user) { build(:user, :admin, :with_organizations) }
+    let(:org) { build(:organization, users: [user]) }
+    let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
+    let(:dashboard) { build(:impac_dashboard, dashboard_type: 'dashboard', organization_ids: [org.uid], currency: 'EUR', settings: metadata) }
+    let(:widget) { build(:impac_widget, dashboard: dashboard, owner: user) }
+    let(:d_kpi) { build(:impac_kpi, dashboard: dashboard) }
+    let(:w_kpi) { build(:impac_kpi, widget: widget) }
+
+    def hash_for_kpi(kpi)
+      {
+        "id" => kpi.id,
+        "element_watched" => kpi.element_watched,
+        "endpoint" => kpi.endpoint
+      }
+    end
+    let(:hash_for_widget) do
+      {
+        "id" => widget.id,
+        "name" => widget.name,
+        "endpoint" => widget.widget_category,
+        "width" => widget.width,
+        "kpis" => [hash_for_kpi(w_kpi)]
+      }
+    end
+    let(:hash_for_dashboard) do
+      {
+        "id" => dashboard.id,
+        "name" => dashboard.name,
+        "full_name" => dashboard.full_name,
+        "currency" => 'EUR',
+        "metadata" => metadata.deep_stringify_keys,
+        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name}],
+        "kpis" => [hash_for_kpi(d_kpi)],
+        "widgets" => [hash_for_widget]
+      }
+    end
+
+    # =============================================================================================================
+
+    before do
+      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
+      sign_in user
+    end
+
+    describe 'GET #index' do
+      subject { get :index }
+
+      before do
+        api_stub_for(
+          get: '/dashboards',
+          # params: { filter: { 'dashboard_type' => 'dashboard' } },
+          response: from_api([dashboard])
+        )
+      end
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+
+      it_behaves_like "a jpi v1 admin action"
+
+      it 'returns a list of dashboards' do
+        subject
+        expect(JSON.parse(response.body)).to eq([hash_for_dashboard])
+      end
+    end
+
+    describe 'POST #create' do
+      subject { post :create, dashboard: dashboard_params }
+
+      let(:dashboard_params) do
+        {
+          name: dashboard.name,
+          currency: dashboard.currency,
+          organization_ids: [org.id]
+        }
+      end
+
+      before do
+        # TODO: stub params?
+        api_stub_for(
+          post: "/dashboards",
+          response: from_api(dashboard)
+        )
+      end
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+
+      it_behaves_like "a jpi v1 admin action"
+
+      it 'returns a dashboard' do
+        subject
+        expect(JSON.parse(response.body)).to eq(hash_for_dashboard)
+      end
+
+    end
+
+    describe 'PUT #update' do
+      subject { put :update, id: dashboard.id, dashboard: dashboard_params }
+
+      let(:dashboard_params) do
+        {
+          name: dashboard.name,
+          currency: dashboard.currency,
+          organization_ids: [org.id]
+        }
+      end
+
+      before do
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}",
+          response: from_api(dashboard)
+        )
+        api_stub_for(
+          put: "/dashboards/#{dashboard.id}",
+          response: from_api(dashboard)
+        )
+      end
+
+      include_context "#{described_class}: dashboard dependencies stubs"
+
+      it_behaves_like "a jpi v1 admin action"
+
+      it 'returns a dashboard' do
+        subject
+        expect(JSON.parse(response.body)).to eq(hash_for_dashboard)
+      end
+    end
+
+    describe 'DELETE destroy' do
+      subject { delete :destroy, id: dashboard.id }
+
+      before do
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}",
+          response: from_api(dashboard)
+        )
+        api_stub_for(
+          delete: "/dashboards/#{dashboard.id}",
+          response: from_api(nil)
+        )
+      end
+
+      it_behaves_like "a jpi v1 admin action"
+    end
+  end
+end

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
@@ -84,7 +84,7 @@ module MnoEnterprise
       before do
         api_stub_for(
           get: '/dashboards',
-          # params: { filter: { 'dashboard_type' => 'dashboard' } },
+          params: { filter: { 'owner_type' => 'User', 'owner_id' => user.id } },
           response: from_api([dashboard])
         )
       end
@@ -142,8 +142,12 @@ module MnoEnterprise
 
       before do
         api_stub_for(
-          get: "/dashboards/#{dashboard.id}",
-          response: from_api(dashboard)
+          get: "/dashboards",
+          params: {
+            filter: { 'id' => dashboard.id, 'owner_id' => user.id, 'owner_type' => 'User' },
+            limit: 1
+          },
+          response: from_api([dashboard])
         )
         api_stub_for(
           put: "/dashboards/#{dashboard.id}",
@@ -166,8 +170,12 @@ module MnoEnterprise
 
       before do
         api_stub_for(
-          get: "/dashboards/#{dashboard.id}",
-          response: from_api(dashboard)
+          get: "/dashboards",
+          params: {
+            filter: { 'id' => dashboard.id, 'owner_id' => user.id, 'owner_type' => 'User' },
+            limit: 1
+          },
+          response: from_api([dashboard])
         )
         api_stub_for(
           delete: "/dashboards/#{dashboard.id}",

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_controller_spec.rb
@@ -1,82 +1,13 @@
 require 'rails_helper'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_impac_controller'
 
 module MnoEnterprise
   describe Jpi::V1::Admin::Impac::DashboardsController, type: :controller do
-    # include MnoEnterprise::TestingSupport::JpiV1TestHelper
-    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
-    render_views
-    routes { MnoEnterprise::Engine.routes }
-    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+    include_context MnoEnterprise::Jpi::V1::Admin::BaseResourceController
 
-
-    # =============================================================================================================
-    # TODO: DRY
-    # =============================================================================================================
-
-    RSpec.shared_context "#{described_class}: dashboard dependencies stubs" do
-      before do
-        api_stub_for(
-          get: "/organizations?filter[uid.in][]=#{org.uid}",
-          response: from_api([org])
-        )
-        api_stub_for(
-          get: "/dashboards/#{dashboard.id}/widgets",
-          response: from_api([widget])
-        )
-        api_stub_for(
-          get: "/dashboards/#{dashboard.id}/kpis",
-          response: from_api([d_kpi])
-        )
-        api_stub_for(
-          get: "/widgets/#{widget.id}/kpis",
-          response: from_api([w_kpi])
-        )
-      end
-    end
-
-    let(:user) { build(:user, :admin, :with_organizations) }
-    let(:org) { build(:organization, users: [user]) }
-    let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
-    let(:dashboard) { build(:impac_dashboard, dashboard_type: 'dashboard', organization_ids: [org.uid], currency: 'EUR', settings: metadata) }
-    let(:widget) { build(:impac_widget, dashboard: dashboard, owner: user) }
-    let(:d_kpi) { build(:impac_kpi, dashboard: dashboard) }
-    let(:w_kpi) { build(:impac_kpi, widget: widget) }
-
-    def hash_for_kpi(kpi)
-      {
-        "id" => kpi.id,
-        "element_watched" => kpi.element_watched,
-        "endpoint" => kpi.endpoint
-      }
-    end
-    let(:hash_for_widget) do
-      {
-        "id" => widget.id,
-        "name" => widget.name,
-        "endpoint" => widget.widget_category,
-        "width" => widget.width,
-        "kpis" => [hash_for_kpi(w_kpi)]
-      }
-    end
-    let(:hash_for_dashboard) do
-      {
-        "id" => dashboard.id,
-        "name" => dashboard.name,
-        "full_name" => dashboard.full_name,
-        "currency" => 'EUR',
-        "metadata" => metadata.deep_stringify_keys,
-        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name}],
-        "kpis" => [hash_for_kpi(d_kpi)],
-        "widgets" => [hash_for_widget]
-      }
-    end
-
-    # =============================================================================================================
-
-    before do
-      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
-      sign_in user
-    end
+    include MnoEnterprise::TestingSupport::SharedContexts::JpiV1AdminImpacController
+    include_context 'MnoEnterprise::Jpi::V1::Admin::Impac'
 
     describe 'GET #index' do
       subject { get :index }

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/dashboard_templates_controller_spec.rb
@@ -1,75 +1,20 @@
 require 'rails_helper'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_impac_controller'
 
 module MnoEnterprise
   describe Jpi::V1::Admin::Impac::DashboardTemplatesController, type: :controller do
-    # include MnoEnterprise::TestingSupport::JpiV1TestHelper
-    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
-    render_views
-    routes { MnoEnterprise::Engine.routes }
-    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+    include_context MnoEnterprise::Jpi::V1::Admin::BaseResourceController
 
-    RSpec.shared_context "#{described_class}: dashboard dependencies stubs" do
-      before do
-        api_stub_for(
-          get: "/users/#{user.id}/organizations",
-          response: from_api([org])
-        )
-        api_stub_for(
-          get: "/dashboards/#{template.id}/widgets",
-          response: from_api([widget])
-        )
-        api_stub_for(
-          get: "/dashboards/#{template.id}/kpis",
-          response: from_api([d_kpi])
-        )
-        api_stub_for(
-          get: "/widgets/#{widget.id}/kpis",
-          response: from_api([w_kpi])
-        )
-      end
+    include MnoEnterprise::TestingSupport::SharedContexts::JpiV1AdminImpacController
+    include_context 'MnoEnterprise::Jpi::V1::Admin::Impac' do
+      let(:dashboard) { template }
     end
 
-    let(:user) { build(:user, :admin, :with_organizations) }
-    let(:org) { build(:organization, users: [user]) }
-    let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
     let(:template) { build(:impac_dashboard, dashboard_type: 'template', organization_ids: [org.uid], currency: 'EUR', settings: metadata, owner_type: nil, owner_id: nil, published: true) }
-    let(:widget) { build(:impac_widget, dashboard: template) }
-    let(:d_kpi) { build(:impac_kpi, dashboard: template) }
-    let(:w_kpi) { build(:impac_kpi, widget: widget) }
 
-    def hash_for_kpi(kpi)
-      {
-        "id" => kpi.id,
-        "element_watched" => kpi.element_watched,
-        "endpoint" => kpi.endpoint
-      }
-    end
-    let(:hash_for_widget) do
-      {
-        "id" => widget.id,
-        "name" => widget.name,
-        "endpoint" => widget.widget_category,
-        "width" => widget.width,
-        "kpis" => [hash_for_kpi(w_kpi)]
-      }
-    end
     let(:hash_for_template) do
-      {
-        "id" => template.id,
-        "name" => template.name,
-        "full_name" => template.full_name,
-        "currency" => 'EUR',
-        "metadata" => metadata.deep_stringify_keys,
-        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name}],
-        "kpis" => [hash_for_kpi(d_kpi)],
-        "widgets" => [hash_for_widget],
-        "published" => true
-      }
-    end
-
-    before do
-      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
-      sign_in user
+      hash_for_dashboard.merge("published" => true)
     end
       
     describe '#index' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/kpis_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/kpis_controller_spec.rb
@@ -1,12 +1,9 @@
 require 'rails_helper'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller'
 
 module MnoEnterprise
   describe Jpi::V1::Admin::Impac::KpisController, type: :controller do
-    # include MnoEnterprise::TestingSupport::JpiV1TestHelper
-    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
-    render_views
-    routes { MnoEnterprise::Engine.routes }
-    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+    include_context MnoEnterprise::Jpi::V1::Admin::BaseResourceController
 
     let(:user) { build(:user, :admin, :with_organizations) }
     let(:org) { build(:organization, users: [user]) }
@@ -21,11 +18,6 @@ module MnoEnterprise
         "element_watched" => kpi.element_watched,
         "endpoint" => kpi.endpoint
       }
-    end
-
-    before do
-      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
-      sign_in user
     end
 
     describe '#create' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/impac/widgets_controller_spec.rb
@@ -1,12 +1,9 @@
 require 'rails_helper'
+require 'mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller'
 
 module MnoEnterprise
   describe Jpi::V1::Admin::Impac::WidgetsController, type: :controller do
-    # include MnoEnterprise::TestingSupport::JpiV1TestHelper
-    include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
-    render_views
-    routes { MnoEnterprise::Engine.routes }
-    before { request.env["HTTP_ACCEPT"] = 'application/json' }
+    include_context MnoEnterprise::Jpi::V1::Admin::BaseResourceController
 
     let(:user) { build(:user, :admin, :with_organizations) }
     let(:org) { build(:organization, users: [user]) }
@@ -32,11 +29,6 @@ module MnoEnterprise
         "kpis" => [hash_for_kpi],
         "layouts" => widget.layouts
       }
-    end
-
-    before do
-      api_stub_for(get: "/users/#{user.id}", response: from_api(user))
-      sign_in user
     end
 
     describe '#create' do

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -70,7 +70,8 @@ module MnoEnterprise
           'name' => organization.name,
           'soa_enabled' => organization.soa_enabled,
           'created_at' => organization.created_at,
-          'account_frozen' => organization.account_frozen
+          'account_frozen' => organization.account_frozen,
+          'financial_year_end_month' => organization.financial_year_end_month
         }],
         'metadata' => {'pagination' => {'count' => 1}}
       }

--- a/api/spec/routing/mno_enterprise/jpi/v1/admin/impac/dashboards_controller_routing_spec.rb
+++ b/api/spec/routing/mno_enterprise/jpi/v1/admin/impac/dashboards_controller_routing_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+module MnoEnterprise
+  RSpec.describe Jpi::V1::Admin::Impac::DashboardsController, type: :routing do
+    routes { MnoEnterprise::Engine.routes }
+
+    it 'routes to #index' do
+      expect(get('/jpi/v1/admin/impac/dashboards')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#index', format: 'json')
+    end
+
+    it 'routes to #create' do
+      expect(post('/jpi/v1/admin/impac/dashboards')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#create', format: 'json')
+    end
+
+    it 'routes to #update' do
+      expect(put('/jpi/v1/admin/impac/dashboards/2')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#update', id: '2', format: 'json')
+      expect(patch('/jpi/v1/admin/impac/dashboards/2')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#update', id: '2', format: 'json')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete('/jpi/v1/admin/impac/dashboards/2')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#destroy', id: '2', format: 'json')
+    end
+  end
+end

--- a/api/spec/routing/mno_enterprise/jpi/v1/admin/impac/dashboards_controller_routing_spec.rb
+++ b/api/spec/routing/mno_enterprise/jpi/v1/admin/impac/dashboards_controller_routing_spec.rb
@@ -20,5 +20,9 @@ module MnoEnterprise
     it 'routes to #destroy' do
       expect(delete('/jpi/v1/admin/impac/dashboards/2')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#destroy', id: '2', format: 'json')
     end
+
+    it 'routes to #copy' do
+      expect(post('/jpi/v1/admin/impac/dashboards/2/copy')).to route_to('mno_enterprise/jpi/v1/admin/impac/dashboards#copy', id: '2', format: 'json')
+    end
   end
 end

--- a/api/spec/routing/mno_enterprise/jpi/v1/impac/dashboards_controller_routing_spec.rb
+++ b/api/spec/routing/mno_enterprise/jpi/v1/impac/dashboards_controller_routing_spec.rb
@@ -24,5 +24,9 @@ module MnoEnterprise
     it 'routes to #destroy' do
       expect(delete('/jpi/v1/impac/dashboards/2')).to route_to('mno_enterprise/jpi/v1/impac/dashboards#destroy', id: '2')
     end
+
+    it 'routes to #copy' do
+      expect(post('/jpi/v1/impac/dashboards/2/copy')).to route_to('mno_enterprise/jpi/v1/impac/dashboards#copy', id: '2')
+    end
   end
 end

--- a/core/lib/mno_enterprise/concerns/models/organization.rb
+++ b/core/lib/mno_enterprise/concerns/models/organization.rb
@@ -41,7 +41,12 @@ module MnoEnterprise::Concerns::Models::Organization
 
     scope :in_arrears, -> { where(in_arrears?: true) }
     scope :active, -> { where(account_frozen: false) }
-    scope :include_acl, ->(imp_id) { tap { |x| x.params.merge!(include_acl?: true, account_manager_id: imp_id) } }
+    scope :include_acl, ->(imp_id) do
+      tap do |x|
+        x.params[:include_acl?] = true
+        x.params[:account_manager_id] = imp_id if Settings.admin_panel.account_manager.enabled?
+      end
+    end
     default_scope lambda { where(account_frozen: false) }
 
     #================================

--- a/core/lib/mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller.rb
+++ b/core/lib/mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_controller.rb
@@ -1,0 +1,13 @@
+RSpec.shared_context MnoEnterprise::Jpi::V1::Admin::BaseResourceController do
+  include MnoEnterprise::TestingSupport::SharedExamples::JpiV1Admin
+
+  render_views
+  routes { MnoEnterprise::Engine.routes }
+  before { request.env["HTTP_ACCEPT"] = 'application/json' }
+
+  # user is stubbed in the controller?
+  before do
+    api_stub_for(get: "/users/#{user.id}", response: from_api(user))
+    sign_in(user)
+  end
+end

--- a/core/lib/mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_impac_controller.rb
+++ b/core/lib/mno_enterprise/testing_support/shared_contexts/jpi_v1_admin_impac_controller.rb
@@ -1,0 +1,73 @@
+module MnoEnterprise::TestingSupport::SharedContexts::JpiV1AdminImpacController
+  def hash_for_kpi(kpi)
+    {
+      "id" => kpi.id,
+      "element_watched" => kpi.element_watched,
+      "endpoint" => kpi.endpoint
+    }
+  end
+
+  shared_context 'MnoEnterprise::Jpi::V1::Admin::Impac' do
+    shared_context "#{described_class}: dashboard dependencies stubs" do
+      before do
+        # Not ideal but this is a nested context
+        if described_class == MnoEnterprise::Jpi::V1::Admin::Impac::DashboardsController
+          api_stub_for(
+            get: "/organizations?filter[uid.in][]=#{org.uid}",
+            response: from_api([org])
+          )
+        end
+        if described_class == MnoEnterprise::Jpi::V1::Admin::Impac::DashboardTemplatesController
+          api_stub_for(
+            get: "/users/#{user.id}/organizations",
+            response: from_api([org])
+          )
+        end
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}/widgets",
+          response: from_api([widget])
+        )
+        api_stub_for(
+          get: "/dashboards/#{dashboard.id}/kpis",
+          response: from_api([d_kpi])
+        )
+        api_stub_for(
+          get: "/widgets/#{widget.id}/kpis",
+          response: from_api([w_kpi])
+        )
+      end
+    end
+
+    let(:user) { build(:user, :admin, :with_organizations) }
+    let(:org) { build(:organization, users: [user]) }
+    let(:metadata) { { hist_parameters: { from: '2015-01-01', to: '2015-03-31', period: 'MONTHLY' } } }
+    let(:dashboard) { build(:impac_dashboard, dashboard_type: 'dashboard', organization_ids: [org.uid], currency: 'EUR', settings: metadata) }
+    let(:widget) { build(:impac_widget, dashboard: dashboard, owner: user) }
+    let(:d_kpi) { build(:impac_kpi, dashboard: dashboard) }
+    let(:w_kpi) { build(:impac_kpi, widget: widget) }
+
+    let(:hash_for_widget) do
+      {
+        "id" => widget.id,
+        "name" => widget.name,
+        "endpoint" => widget.widget_category,
+        "width" => widget.width,
+        "kpis" => [hash_for_kpi(w_kpi)]
+      }
+    end
+    let(:hash_for_dashboard) do
+      {
+        "id" => dashboard.id,
+        "name" => dashboard.name,
+        "full_name" => dashboard.full_name,
+        "currency" => 'EUR',
+        "metadata" => metadata.deep_stringify_keys,
+        "data_sources" => [{ "id" => org.id, "uid" => org.uid, "label" => org.name}],
+        "kpis" => [hash_for_kpi(d_kpi)],
+        "widgets" => [hash_for_widget]
+      }
+    end
+  end
+end
+
+


### PR DESCRIPTION
## Staff Dashboard
This feature allow staff to create their own dashboards to view their customer data from the admin panel.
The dashboard are owned by the staff but use the customer company as data source.
This require the IDMv2 to be enabled so that staff members are authorised to view their customer data.

See the (incoming) mnoe-admin-panel PR for screeenshots.

Most of the changes boil down to adding a new `/jpi/v1/admin/impac/dashboards` to allow staff to manipulate dashboard.

The commits should be logically isolated to make the review easier.
~I've separated 995547c...2415f52 in #808 as it's just general improvement and might help with the review.~ Rebased

I also had a stab at DRYing the specs (a69662b7):
* JpiV1AdminController context for all the basic setup
* Reduce duplication between Dashboard and DashboardController
Let me know if that actually makes it harder, I'll drop the commit.
Or if you have other ideas.

Know issues:
* Advisor Dashboards don't support KPI yet (not enabled for KAPPA). Should be easy to implement based on the Widget.