### PR TITLE
[MACAWSUP-93] Failed login attempt error

### DIFF
--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -90,6 +90,7 @@ module MnoEnterprise
     custom_endpoint :authenticate, on: :collection, request_method: :post
     custom_endpoint :update_password, on: :member, request_method: :patch
     custom_endpoint :update_clients, on: :member, request_method: :patch
+    custom_endpoint :increment_failed_attempts, on: :member, request_method: :patch # Custom endpoint to support Devise Lockable module
 
     #================================
     # Class Methods
@@ -278,6 +279,17 @@ module MnoEnterprise
 
     def admin?
       admin_role.to_s.casecmp(ADMIN_ROLE).zero?
+    end
+
+    # Support Devise Lockable module
+    # When a failed attempt is made, Devise calls
+    # increment_counter which is an ActiveRecord method
+    def self.increment_counter(counter_name, id)
+      if counter_name == :failed_attempts
+        # Custom endpoint which will ultimately call increment_counter
+        # on the user in MnoHub
+        self.new(id: id).increment_failed_attempts
+      end
     end
   end
 end


### PR DESCRIPTION
Use custom endpoint to support devise lockable module.
Devise uses the ActiveRecord ::increment_counter method to record failed
login attempts. The custom endpoint will trigger this method call in
MnoHub.