### PR TITLE
[MARLIN-748] add deeplink endpoint to pages controller

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,7 +1,7 @@
 MnoEnterprise::Engine.routes.draw do
   # Generic routes
   get '/launch/:id', to: 'pages#launch', constraints: {id: /[\w\-\.:]+/}
-  get '/deeplink/:oid/:etype/:eid', to: 'pages#deeplink', constraints: {oid: /[\w\-\.]+/, eid: /[\w\-]+/}
+  get '/deeplink/:organization_id/:entity_type/:entity_id', to: 'pages#deeplink', constraints: {organization_id: /[\w\-\.]+/, entity_id: /[\w\-]+/}
   get '/loading/:id', to: 'pages#loading', constraints: {id: /[\w\-\.]+/}
   get '/app_access_unauthorized', to: 'pages#app_access_unauthorized'
   get '/billing_details_required', to: 'pages#billing_details_required'

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,6 +1,7 @@
 MnoEnterprise::Engine.routes.draw do
   # Generic routes
   get '/launch/:id', to: 'pages#launch', constraints: {id: /[\w\-\.:]+/}
+  get '/deeplink/:oid/:etype/:eid', to: 'pages#deeplink', constraints: {oid: /[\w\-\.]+/, eid: /[\w\-]+/}
   get '/loading/:id', to: 'pages#loading', constraints: {id: /[\w\-\.]+/}
   get '/app_access_unauthorized', to: 'pages#app_access_unauthorized'
   get '/billing_details_required', to: 'pages#billing_details_required'

--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -30,11 +30,11 @@ module MnoEnterprise::Concerns::Controllers::PagesController
     redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
   end
 
-  # GET /deeplink/:oid/:etype/:eid?params
+  # GET /deeplink/:organization_id/:entity_type/:entity_id?params
   # Redirect to Mno Enterprise entity deeplink
   # Deeplink an entity (from dashboard) should redirect to this action
   def deeplink
-    redirect_to MnoEnterprise.router.deeplink_url(params[:oid], params[:etype], params[:eid], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
+    redirect_to MnoEnterprise.router.deeplink_url(params[:organization_id], params[:entity_type], params[:entity_id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
   end
 
   # GET /loading/:id

--- a/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/pages_controller.rb
@@ -8,8 +8,8 @@ module MnoEnterprise::Concerns::Controllers::PagesController
   # 'included do' causes the included code to be evaluated in the
   # context where it is included rather than being executed in the module's context
   included do
-    before_filter :authenticate_user!, only: [:launch]
-    before_filter :redirect_to_lounge_if_unconfirmed, only: [:launch]
+    before_filter :authenticate_user!, only: [:launch, :deeplink]
+    before_filter :redirect_to_lounge_if_unconfirmed, only: [:launch, :deeplink]
     helper_method :main_logo_white_bg_path # To use in the provision view
   end
 
@@ -28,6 +28,13 @@ module MnoEnterprise::Concerns::Controllers::PagesController
     app_instance = MnoEnterprise::AppInstance.where(uid: params[:id]).first
     MnoEnterprise::EventLogger.info('app_launch', current_user.id, 'App launched', app_instance)
     redirect_to MnoEnterprise.router.launch_url(params[:id], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
+  end
+
+  # GET /deeplink/:oid/:etype/:eid?params
+  # Redirect to Mno Enterprise entity deeplink
+  # Deeplink an entity (from dashboard) should redirect to this action
+  def deeplink
+    redirect_to MnoEnterprise.router.deeplink_url(params[:oid], params[:etype], params[:eid], {wtk: MnoEnterprise.jwt(user_id: current_user.uid)}.reverse_merge(request.query_parameters))
   end
 
   # GET /loading/:id

--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -44,6 +44,21 @@ module MnoEnterprise
       end
     end
 
+    describe 'GET #deeplink with parameters' do
+      let(:organization) { build(:organization) }
+      let(:etype) { 'invoices' }
+      let(:eid) { SecureRandom.uuid }
+      before { sign_in user }
+      subject { get :deeplink, oid: organization.uid, etype: etype, eid: eid, specific_parameters: 'specific:parameters_value' }
+
+      it_behaves_like "a navigatable protected user action"
+
+      it 'redirects to the mno enterprise deeplink page with a web token and extra params' do
+        subject
+        expect(response).to redirect_to(MnoEnterprise.router.deeplink_url(organization.uid, etype, eid, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific:parameters_value'))
+      end
+    end
+
     describe 'GET #loading' do
       subject { get :loading, id: app_instance.uid }
 

--- a/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/pages_controller_spec.rb
@@ -46,16 +46,16 @@ module MnoEnterprise
 
     describe 'GET #deeplink with parameters' do
       let(:organization) { build(:organization) }
-      let(:etype) { 'invoices' }
-      let(:eid) { SecureRandom.uuid }
+      let(:entity_type) { 'invoices' }
+      let(:entity_id) { SecureRandom.uuid }
       before { sign_in user }
-      subject { get :deeplink, oid: organization.uid, etype: etype, eid: eid, specific_parameters: 'specific:parameters_value' }
+      subject { get :deeplink, organization_id: organization.uid, entity_type: entity_type, entity_id: entity_id, specific_parameters: 'specific:parameters_value' }
 
       it_behaves_like "a navigatable protected user action"
 
       it 'redirects to the mno enterprise deeplink page with a web token and extra params' do
         subject
-        expect(response).to redirect_to(MnoEnterprise.router.deeplink_url(organization.uid, etype, eid, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific:parameters_value'))
+        expect(response).to redirect_to(MnoEnterprise.router.deeplink_url(organization.uid, entity_type, entity_id, wtk: MnoEnterprise.jwt({user_id: user.uid}), specific_parameters: 'specific:parameters_value'))
       end
     end
 

--- a/api/spec/routing/mno_enterprise/pages_controller_routing_spec.rb
+++ b/api/spec/routing/mno_enterprise/pages_controller_routing_spec.rb
@@ -10,7 +10,7 @@ module MnoEnterprise
     end
 
     it "routes to #deeplink" do
-      expect(get("/deeplink/org-1f47/invoices/3456-we43")).to route_to("mno_enterprise/pages#deeplink", oid: 'org-1f47', etype: 'invoices', eid: '3456-we43')
+      expect(get("/deeplink/org-1f47/invoices/3456-we43")).to route_to("mno_enterprise/pages#deeplink", organization_id: 'org-1f47', entity_type: 'invoices', entity_id: '3456-we43')
     end
 
     it "routes to #loading" do

--- a/api/spec/routing/mno_enterprise/pages_controller_routing_spec.rb
+++ b/api/spec/routing/mno_enterprise/pages_controller_routing_spec.rb
@@ -9,7 +9,11 @@ module MnoEnterprise
       expect(get("/launch/bla.mcube.co")).to route_to("mno_enterprise/pages#launch", id: 'bla.mcube.co')
     end
 
-    it "routes to #launch" do
+    it "routes to #deeplink" do
+      expect(get("/deeplink/org-1f47/invoices/3456-we43")).to route_to("mno_enterprise/pages#deeplink", oid: 'org-1f47', etype: 'invoices', eid: '3456-we43')
+    end
+
+    it "routes to #loading" do
       expect(get("/loading/cld-1f47d5s4")).to route_to("mno_enterprise/pages#loading", id: 'cld-1f47d5s4')
       expect(get("/loading/bla.mcube.co")).to route_to("mno_enterprise/pages#loading", id: 'bla.mcube.co')
     end

--- a/core/lib/mno_enterprise/core.rb
+++ b/core/lib/mno_enterprise/core.rb
@@ -55,6 +55,10 @@ module MnoEnterprise
       host_url("/launch/#{id}",opts)
     end
 
+    def deeplink_url(oid,etype,eid,opts = {})
+      host_url("/deeplink/#{oid}/#{etype}/#{eid}", opts)
+    end
+
     def authorize_oauth_url(id,opts = {})
       host_url("/oauth/#{id}/authorize",opts)
     end

--- a/core/lib/mno_enterprise/core.rb
+++ b/core/lib/mno_enterprise/core.rb
@@ -55,8 +55,8 @@ module MnoEnterprise
       host_url("/launch/#{id}",opts)
     end
 
-    def deeplink_url(oid,etype,eid,opts = {})
-      host_url("/deeplink/#{oid}/#{etype}/#{eid}", opts)
+    def deeplink_url(organization_id,entity_type,entity_id,opts = {})
+      host_url("/deeplink/#{organization_id}/#{entity_type}/#{entity_id}", opts)
     end
 
     def authorize_oauth_url(id,opts = {})

--- a/core/spec/mno_enterprise_spec.rb
+++ b/core/spec/mno_enterprise_spec.rb
@@ -46,12 +46,12 @@ describe MnoEnterprise do
     end
 
     describe 'deeplink_url' do
-      let(:oid) { 'org=12s2' }
-      let(:etype) { 'invoices' }
-      let(:eid) { '123245da-2sah4as-344wq' }
+      let(:organization_id) { 'org=12s2' }
+      let(:entity_type) { 'invoices' }
+      let(:entity_id) { '123245da-2sah4as-344wq' }
 
-      let(:url) { "#{root_path}/deeplink/#{oid}/#{etype}/#{eid}" }
-      it { expect(MnoEnterprise.router.deeplink_url(oid, etype, eid)).to eq(url) }
+      let(:url) { "#{root_path}/deeplink/#{organization_id}/#{entity_type}/#{entity_id}" }
+      it { expect(MnoEnterprise.router.deeplink_url(organization_id, entity_type, entity_id)).to eq(url) }
     end
 
     describe 'authorize_oauth_url' do

--- a/core/spec/mno_enterprise_spec.rb
+++ b/core/spec/mno_enterprise_spec.rb
@@ -45,6 +45,15 @@ describe MnoEnterprise do
       it { expect(MnoEnterprise.router.launch_url(id)).to eq(url) }
     end
 
+    describe 'deeplink_url' do
+      let(:oid) { 'org=12s2' }
+      let(:etype) { 'invoices' }
+      let(:eid) { '123245da-2sah4as-344wq' }
+
+      let(:url) { "#{root_path}/deeplink/#{oid}/#{etype}/#{eid}" }
+      it { expect(MnoEnterprise.router.deeplink_url(oid, etype, eid)).to eq(url) }
+    end
+
     describe 'authorize_oauth_url' do
       let(:url) { "#{root_path}/oauth/#{id}/authorize" }
       it { expect(MnoEnterprise.router.authorize_oauth_url(id)).to eq(url) }


### PR DESCRIPTION
As described on the ticket, *mno-enterprise* need to expose the _deeplink_ endpoint as below:

`get '/deeplink/:oid/:etype/:eid', to: 'pages#deeplink', constraints: {oid: /[\w\-\.]+/, eid: /[\w\-]+/}`