### PR TITLE
[MACAWSUP-117] Add devise session limitable

### DIFF
--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -67,9 +67,10 @@ module MnoEnterprise
       devise_modules = [
         :remote_authenticatable, :recoverable, :rememberable,
         :trackable, :validatable, :lockable, :confirmable, :timeoutable, :password_expirable,
-        :omniauthable, :session_limitable
+        :omniauthable
       ]
       devise_modules << :registerable if Settings&.dashboard&.registration&.enabled
+      devise_modules << :session_limitable if Settings&.authentication&.session_limitable&.enabled
       devise(*devise_modules, omniauth_providers: Devise.omniauth_providers)
     end
     configure_devise

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -66,7 +66,7 @@ module MnoEnterprise
       devise_modules = [
         :remote_authenticatable, :recoverable, :rememberable,
         :trackable, :validatable, :lockable, :confirmable, :timeoutable, :password_expirable,
-        :omniauthable
+        :omniauthable, :session_limitable
       ]
       devise_modules << :registerable if Settings&.dashboard&.registration&.enabled
       devise(*devise_modules, omniauth_providers: Devise.omniauth_providers)

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -49,6 +49,7 @@ module MnoEnterprise
     property :geo_currency, type: :string
     property :failed_attempts
     property :password_changed_at
+    property :unique_session_id
 
     has_one :sub_tenant
 

--- a/core/app/models/mno_enterprise/user.rb
+++ b/core/app/models/mno_enterprise/user.rb
@@ -49,7 +49,7 @@ module MnoEnterprise
     property :geo_currency, type: :string
     property :failed_attempts
     property :password_changed_at
-    property :unique_session_id
+    # property :unique_session_id
 
     has_one :sub_tenant
 
@@ -70,7 +70,7 @@ module MnoEnterprise
         :omniauthable
       ]
       devise_modules << :registerable if Settings&.dashboard&.registration&.enabled
-      devise_modules << :session_limitable if Settings&.authentication&.session_limitable&.enabled
+      # devise_modules << :session_limitable if Settings&.authentication&.session_limitable&.enabled
       devise(*devise_modules, omniauth_providers: Devise.omniauth_providers)
     end
     configure_devise

--- a/core/config/initializers/00_tenant_config_schema.rb
+++ b/core/config/initializers/00_tenant_config_schema.rb
@@ -703,26 +703,7 @@ MnoEnterprise::CONFIG_JSON_SCHEMA = {
               enum: %w(AED AUD CAD EUR GBP HKD JPY NZD SGD USD)
             }
           }
-        }
-      }
-    },
-    authentication: {
-      title: 'Authentication feature',
-      description: 'Authentication feature',
-      type: 'object',
-      properties: {
-        session_limitable: {
-          title: 'Session limitable',
-          description: 'One session usable per account at once',
-          type: 'object',
-          properties: {
-            enabled: {
-              type: 'boolean',
-              description: 'Enabled?',
-              default: false
-            }
-          }
-        }
+        },
       }
     }
   }

--- a/core/config/initializers/00_tenant_config_schema.rb
+++ b/core/config/initializers/00_tenant_config_schema.rb
@@ -703,7 +703,26 @@ MnoEnterprise::CONFIG_JSON_SCHEMA = {
               enum: %w(AED AUD CAD EUR GBP HKD JPY NZD SGD USD)
             }
           }
-        },
+        }
+      }
+    },
+    authentication: {
+      title: 'Authentication feature',
+      description: 'Authentication feature',
+      type: 'object',
+      properties: {
+        session_limitable: {
+          title: 'Session limitable',
+          description: 'One session usable per account at once',
+          type: 'object',
+          properties: {
+            enabled: {
+              type: 'boolean',
+              description: 'Enabled?',
+              default: false
+            }
+          }
+        }
       }
     }
   }

--- a/core/config/locales/devise.en.yml
+++ b/core/config/locales/devise.en.yml
@@ -16,6 +16,7 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      session_limited: "Your login credentials were used in another browser. Please sign in again to continue in this browser."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -1,0 +1,27 @@
+# After each sign in, update unique_session_id.
+# This is only triggered when the user is explicitly set (with set_user)
+# and on authentication. Retrieving the user from session (:fetch) does
+# not trigger it.
+Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
+  if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
+    unique_session_id = Devise.friendly_token
+    warden.session(options[:scope])['unique_session_id'] = unique_session_id
+    record.update_unique_session_id!(unique_session_id)
+  end
+end
+
+# Each time a record is fetched from session we check if a new session from another
+# browser was opened for the record or not, based on a unique session identifier.
+# If so, the old account is logged out and redirected to the sign in page on the next request.
+Warden::Manager.after_set_user :only => :fetch do |record, warden, options|
+  scope = options[:scope]
+  env   = warden.request.env
+
+  if record.respond_to?(:unique_session_id) && warden.authenticated?(scope) && options[:store] != false
+    if record.unique_session_id != warden.session(scope)['unique_session_id'] && !env['devise.skip_session_limitable']
+      warden.raw_session.clear
+      warden.logout(scope)
+      throw :warden, :scope => scope, :message => :session_limited
+    end
+  end
+end

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -6,7 +6,7 @@ Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
   if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
     unique_session_id = Devise.friendly_token
     warden.session(options[:scope])['unique_session_id'] = unique_session_id
-    # record.update_unique_session_id!(unique_session_id)
+    record.update_unique_session_id!(unique_session_id)
   end
 end
 

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -3,8 +3,6 @@
 # and on authentication. Retrieving the user from session (:fetch) does
 # not trigger it.
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  return unless Settings&.authentication&.session_limitable&.enabled
-
   if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
     unique_session_id = Devise.friendly_token
     warden.session(options[:scope])['unique_session_id'] = unique_session_id
@@ -16,8 +14,6 @@ end
 # browser was opened for the record or not, based on a unique session identifier.
 # If so, the old account is logged out and redirected to the sign in page on the next request.
 Warden::Manager.after_set_user only: :fetch do |record, warden, options|
-  return unless Settings&.authentication&.session_limitable&.enabled
-
   scope = options[:scope]
   env   = warden.request.env
 

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -2,7 +2,9 @@
 # This is only triggered when the user is explicitly set (with set_user)
 # and on authentication. Retrieving the user from session (:fetch) does
 # not trigger it.
-Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
+Warden::Manager.after_set_user except: :fetch do |record, warden, options|
+  return unless Settings&.authentication&.session_limitable&.enabled
+
   if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
     unique_session_id = Devise.friendly_token
     warden.session(options[:scope])['unique_session_id'] = unique_session_id
@@ -13,7 +15,9 @@ end
 # Each time a record is fetched from session we check if a new session from another
 # browser was opened for the record or not, based on a unique session identifier.
 # If so, the old account is logged out and redirected to the sign in page on the next request.
-Warden::Manager.after_set_user :only => :fetch do |record, warden, options|
+Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+  return unless Settings&.authentication&.session_limitable&.enabled
+
   scope = options[:scope]
   env   = warden.request.env
 

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -6,7 +6,7 @@ Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
   if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
     unique_session_id = Devise.friendly_token
     warden.session(options[:scope])['unique_session_id'] = unique_session_id
-    record.update_unique_session_id!(unique_session_id)
+    # record.update_unique_session_id!(unique_session_id)
   end
 end
 

--- a/core/lib/devise/hooks/session_limitable.rb
+++ b/core/lib/devise/hooks/session_limitable.rb
@@ -1,27 +1,27 @@
-# After each sign in, update unique_session_id.
-# This is only triggered when the user is explicitly set (with set_user)
-# and on authentication. Retrieving the user from session (:fetch) does
-# not trigger it.
-Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
-    unique_session_id = Devise.friendly_token
-    warden.session(options[:scope])['unique_session_id'] = unique_session_id
-    record.update_unique_session_id!(unique_session_id)
-  end
-end
+# # After each sign in, update unique_session_id.
+# # This is only triggered when the user is explicitly set (with set_user)
+# # and on authentication. Retrieving the user from session (:fetch) does
+# # not trigger it.
+# Warden::Manager.after_set_user except: :fetch do |record, warden, options|
+#   if record.respond_to?(:update_unique_session_id!) && warden.authenticated?(options[:scope])
+#     unique_session_id = Devise.friendly_token
+#     warden.session(options[:scope])['unique_session_id'] = unique_session_id
+#     record.update_unique_session_id!(unique_session_id)
+#   end
+# end
 
-# Each time a record is fetched from session we check if a new session from another
-# browser was opened for the record or not, based on a unique session identifier.
-# If so, the old account is logged out and redirected to the sign in page on the next request.
-Warden::Manager.after_set_user only: :fetch do |record, warden, options|
-  scope = options[:scope]
-  env   = warden.request.env
+# # Each time a record is fetched from session we check if a new session from another
+# # browser was opened for the record or not, based on a unique session identifier.
+# # If so, the old account is logged out and redirected to the sign in page on the next request.
+# Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+#   scope = options[:scope]
+#   env   = warden.request.env
 
-  if record.respond_to?(:unique_session_id) && warden.authenticated?(scope) && options[:store] != false
-    if record.unique_session_id != warden.session(scope)['unique_session_id'] && !env['devise.skip_session_limitable']
-      warden.raw_session.clear
-      warden.logout(scope)
-      throw :warden, :scope => scope, :message => :session_limited
-    end
-  end
-end
+#   if record.respond_to?(:unique_session_id) && warden.authenticated?(scope) && options[:store] != false
+#     if record.unique_session_id != warden.session(scope)['unique_session_id'] && !env['devise.skip_session_limitable']
+#       warden.raw_session.clear
+#       warden.logout(scope)
+#       throw :warden, :scope => scope, :message => :session_limited
+#     end
+#   end
+# end

--- a/core/lib/devise/models/session_limitable.rb
+++ b/core/lib/devise/models/session_limitable.rb
@@ -11,9 +11,11 @@ module Devise
       extend ActiveSupport::Concern
 
       def update_unique_session_id!(unique_session_id)
-        self.unique_session_id = unique_session_id
-
-        save(validate: false)
+        self.attributes = {
+          unique_session_id: unique_session_id
+        }
+        save!
+        reload
       end
     end
   end

--- a/core/lib/devise/models/session_limitable.rb
+++ b/core/lib/devise/models/session_limitable.rb
@@ -12,10 +12,9 @@ module Devise
 
       def update_unique_session_id!(unique_session_id)
         self.unique_session_id = unique_session_id
-        puts self.inspect
-        # save(:validate => false)
-      end
 
+        save(validate: false)
+      end
     end
   end
 end

--- a/core/lib/devise/models/session_limitable.rb
+++ b/core/lib/devise/models/session_limitable.rb
@@ -1,0 +1,21 @@
+require 'devise/hooks/session_limitable'
+
+module Devise
+  module Models
+    # SessionLimited ensures, that there is only one session usable per account at once.
+    # If someone logs in, and some other is logging in with the same credentials,
+    # the session from the first one is invalidated and not usable anymore.
+    # The first one is redirected to the sign page with a message, telling that 
+    # someone used his credentials to sign in.
+    module SessionLimitable
+      extend ActiveSupport::Concern
+
+      def update_unique_session_id!(unique_session_id)
+        self.unique_session_id = unique_session_id
+
+        save(:validate => false)
+      end
+
+    end
+  end
+end

--- a/core/lib/devise/models/session_limitable.rb
+++ b/core/lib/devise/models/session_limitable.rb
@@ -1,22 +1,22 @@
-require 'devise/hooks/session_limitable'
+# require 'devise/hooks/session_limitable'
 
-module Devise
-  module Models
-    # SessionLimited ensures, that there is only one session usable per account at once.
-    # If someone logs in, and some other is logging in with the same credentials,
-    # the session from the first one is invalidated and not usable anymore.
-    # The first one is redirected to the sign page with a message, telling that 
-    # someone used his credentials to sign in.
-    module SessionLimitable
-      extend ActiveSupport::Concern
+# module Devise
+#   module Models
+#     # SessionLimited ensures, that there is only one session usable per account at once.
+#     # If someone logs in, and some other is logging in with the same credentials,
+#     # the session from the first one is invalidated and not usable anymore.
+#     # The first one is redirected to the sign page with a message, telling that 
+#     # someone used his credentials to sign in.
+#     module SessionLimitable
+#       extend ActiveSupport::Concern
 
-      def update_unique_session_id!(unique_session_id)
-        self.attributes = {
-          unique_session_id: unique_session_id
-        }
-        save!
-        reload
-      end
-    end
-  end
-end
+#       def update_unique_session_id!(unique_session_id)
+#         self.attributes = {
+#           unique_session_id: unique_session_id
+#         }
+#         save!
+#         reload
+#       end
+#     end
+#   end
+# end

--- a/core/lib/devise/models/session_limitable.rb
+++ b/core/lib/devise/models/session_limitable.rb
@@ -12,8 +12,8 @@ module Devise
 
       def update_unique_session_id!(unique_session_id)
         self.unique_session_id = unique_session_id
-
-        save(:validate => false)
+        puts self.inspect
+        # save(:validate => false)
       end
 
     end

--- a/core/lib/devise_extension.rb
+++ b/core/lib/devise_extension.rb
@@ -1,6 +1,6 @@
 require 'devise'
 require 'devise/models/password_expirable'
-require 'devise/models/session_limitable'
+# require 'devise/models/session_limitable'
 require 'devise/extension_routes'
 
 # Hook for impersonation
@@ -30,7 +30,7 @@ end
 
 # modules
 Devise.add_module :password_expirable, controller: :password_expirable, model: 'devise/models/password_expirable', route: :password_expired
-Devise.add_module :session_limitable, model: 'devise/models/session_limitable'
+# Devise.add_module :session_limitable, model: 'devise/models/session_limitable'
 
 ActiveSupport.on_load(:action_controller) do
   include DeviseExtension::Controllers::Helpers

--- a/core/lib/devise_extension.rb
+++ b/core/lib/devise_extension.rb
@@ -1,5 +1,6 @@
 require 'devise'
 require 'devise/models/password_expirable'
+require 'devise/models/session_limitable'
 require 'devise/extension_routes'
 
 # Hook for impersonation
@@ -29,6 +30,7 @@ end
 
 # modules
 Devise.add_module :password_expirable, controller: :password_expirable, model: 'devise/models/password_expirable', route: :password_expired
+Devise.add_module :session_limitable, model: 'devise/models/session_limitable'
 
 ActiveSupport.on_load(:action_controller) do
   include DeviseExtension::Controllers::Helpers


### PR DESCRIPTION
jira: https://maestrano.atlassian.net//browse/MACAWSUP-117

There's a corresponding PR for maestrano hub to add unique_session_id to user's table. Please see jira ticket for link.

For this ticket:

-	Extension Routes
Not needed as per: https://github.com/phatworx/devise_security_extension/blob/master/lib/devise_security_extension/routes.rb

-	Devise Extension
Require session_limitable model and add module as per:
https://github.com/phatworx/devise_security_extension/blob/b2ee978af7d49f0fb0e7271c6ac074dfb4d39353/lib/devise_security_extension.rb

-	Session Limitable model
File created as per:
https://github.com/phatworx/devise_security_extension/blob/b2ee978af7d49f0fb0e7271c6ac074dfb4d39353/lib/devise_security_extension/models/session_limitable.rb

-	Session Limitable hook
File created as per:
https://github.com/phatworx/devise_security_extension/blob/b2ee978af7d49f0fb0e7271c6ac074dfb4d39353/lib/devise_security_extension/models/session_limitable.rb

