### PR TITLE
[KAPP-191] Fix account manager ACL

### DIFF
--- a/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/admin/users_controller.rb
@@ -30,13 +30,19 @@ module MnoEnterprise
 
     # GET /mnoe/jpi/v1/admin/users/1
     def show
-      @user = MnoEnterprise::User.find(params[:id])
-
-      query = @user.organizations.all
+      query = MnoEnterprise::User.all
       query.params.merge!(account_manager_scope)
-      @user_organizations = query.fetch
+      @user = query.find(params[:id])
 
-      @user_clients = @user.clients
+      if @user
+        query = @user.organizations.all
+        query.params.merge!(account_manager_scope)
+        @user_organizations = query.fetch
+
+        @user_clients = @user.clients
+      else
+        render_not_found('user')
+      end
     end
 
     # POST /mnoe/jpi/v1/admin/users

--- a/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
+++ b/api/app/controllers/mno_enterprise/jpi/v1/base_resource_controller.rb
@@ -28,17 +28,5 @@ module MnoEnterprise
         end
         true
       end
-
-      def render_not_found(resource)
-        render json: { errors: {message: "#{resource.titleize} not found (id=#{params[:id]})", code: 404, params: params} }, status: :not_found
-      end
-
-      def render_bad_request(attempted_action, issue)
-        render json: { errors: {message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params} }, status: :bad_request
-      end
-
-      def render_forbidden_request(attempted_action)
-        render json: { errors: {message: "Error while trying to #{attempted_action}: you do not have permission", code: 403} }, status: :forbidden
-      end
   end
 end

--- a/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/organizations_controller.rb
+++ b/api/lib/mno_enterprise/concerns/controllers/jpi/v1/admin/organizations_controller.rb
@@ -41,8 +41,15 @@ module MnoEnterprise::Concerns::Controllers::Jpi::V1::Admin::OrganizationsContro
 
   # GET /mnoe/jpi/v1/admin/organizations/1
   def show
-    @organization = MnoEnterprise::Organization.find(params[:id])
-    @organization_active_apps = @organization.app_instances.active.to_a
+    rel = MnoEnterprise::Organization.all
+    rel.params.merge!(account_manager_scope)
+    @organization = rel.find(params[:id])
+
+    if @organization
+      @organization_active_apps = @organization.app_instances.active.to_a
+    else
+      render_not_found('organization')
+    end
   end
 
   # GET /mnoe/jpi/v1/admin/organizations/in_arrears

--- a/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
+++ b/api/spec/controllers/mno_enterprise/jpi/v1/admin/organizations_controller_spec.rb
@@ -117,7 +117,6 @@ module MnoEnterprise
 
         context 'search' do
           subject { get :index, terms: "{\"name.like\":\"%search%\"}" }
-          let(:org) { build(:organization, name: 'QWE Corp')}
 
           # Remove the stub to  /organizations so we can test the params (filter, account_manager_id)
           before { api_stub_remove(get: "/organizations", response: from_api([organization])) }

--- a/core/app/controllers/mno_enterprise/application_controller.rb
+++ b/core/app/controllers/mno_enterprise/application_controller.rb
@@ -154,5 +154,17 @@ module MnoEnterprise
         format.json {render json: {error: 'API hub unavailable'}, status: @status}
       end
     end
+
+    def render_not_found(resource)
+      render json: { errors: {message: "#{resource.titleize} not found (id=#{params[:id]})", code: 404, params: params} }, status: :not_found
+    end
+
+    def render_bad_request(attempted_action, issue)
+      render json: { errors: {message: "Error while trying to #{attempted_action}: #{issue}", code: 400, params: params} }, status: :bad_request
+    end
+
+    def render_forbidden_request(attempted_action)
+      render json: { errors: {message: "Error while trying to #{attempted_action}: you do not have permission", code: 403} }, status: :forbidden
+    end
   end
 end


### PR DESCRIPTION
Fix account manager ACL which wasn't applied on:
- `#index` search
- `#show`

Also fix the `#index` to use `current_user` for scoping rather than a parameters passed by the frontend.

Requires maestrano/maestrano-hub#1211 for the `#show` scoping